### PR TITLE
Addition of nip fields

### DIFF
--- a/d2bs/kolbot/libs/NTItemParser.dbl
+++ b/d2bs/kolbot/libs/NTItemParser.dbl
@@ -435,9 +435,27 @@ NTIP.ParseLineInt = function (input, info) {
 				p_end += 2;
 
 				break;
+			case 'europe':
+			case 'uswest':
+			case 'useast':
+			case 'asia':
+				p_result[0]+= '("'+me.realm.toLowerCase()+'"==="'+property.toLowerCase()+'")';
+
+				break;
+			case 'ladder':
+				p_result[0] += "me.ladder";
+
+				break;
+			case 'hardcore':
+				p_result[0] += "(!!me.playertype)";
+
+				break;
+			case 'classic':
+				p_result[0] += "(!me.gametype)";
+
+				break;
 			default:
 				Misc.errorReport("Unknown property: " + property + " File: " + info.file + " Line: " + info.line);
-
 				return false;
 			}
 
@@ -451,7 +469,6 @@ NTIP.ParseLineInt = function (input, info) {
 
 			if (p_section[i].substring(p_start, p_end) === "=") {
 				Misc.errorReport("Unexpected = at line " + info.line + " in " + info.file);
-
 				return false;
 			}
 

--- a/d2bs/kolbot/libs/NTItemParser.dbl
+++ b/d2bs/kolbot/libs/NTItemParser.dbl
@@ -439,7 +439,7 @@ NTIP.ParseLineInt = function (input, info) {
 			case 'uswest':
 			case 'useast':
 			case 'asia':
-				p_result[0]+= '("'+me.realm.toLowerCase()+'"==="'+property.toLowerCase()+'")';
+				p_result[0] += '("'+me.realm.toLowerCase() + '"==="' + property.toLowerCase() + '")';
 
 				break;
 			case 'ladder':
@@ -456,6 +456,7 @@ NTIP.ParseLineInt = function (input, info) {
 				break;
 			default:
 				Misc.errorReport("Unknown property: " + property + " File: " + info.file + " Line: " + info.line);
+
 				return false;
 			}
 
@@ -469,6 +470,7 @@ NTIP.ParseLineInt = function (input, info) {
 
 			if (p_section[i].substring(p_start, p_end) === "=") {
 				Misc.errorReport("Unexpected = at line " + info.line + " in " + info.file);
+
 				return false;
 			}
 


### PR DESCRIPTION
The addition of a few fields for nip files. These are bound to the realm, or type of char your play at.

## Realms
[Europe] 
[USWest] 
[USEast]
[Asia]

## Other stuff
[Ladder]
[Hardcore]
[Classic]

All these fields need to be used with in the `type` field of the nip (before the first #)
So here is some ridiculouse example:
```
// Only griswold's on ladder, hardcore, classic, europe
[name] == vortexshield && [quality] == set && [classic] && [hardcore] && [ladder] && [useast] # [defense] == 333
```

In case you want to do stuff specificly for nonladder, or exp, or softcore, you can use the ! operator.
```
// Only griswold's on non ladder, softcore, not classic, europe
[name] == vortexshield && [quality] == set && ![classic] && ![hardcore] && ![ladder] && [useast] # [defense] == 333
```