### PR TITLE
Add doChores before muling if lowGold is set

### DIFF
--- a/d2bs/kolbot/libs/AutoMule.js
+++ b/d2bs/kolbot/libs/AutoMule.js
@@ -108,6 +108,10 @@ var AutoMule = {
 		if (info && info.hasOwnProperty("muleInfo")) {
 			items = this.getMuleItems();
 
+			if (info.muleInfo.hasOwnProperty("usedInventoryTrigger") && Storage.Inventory.UsedSpacePercent() >= info.muleInfo.usedInventoryTrigger && Config.LowGold > 0) {
+				Town.doChores();
+			}
+
 			if (info.muleInfo.hasOwnProperty("usedStashTrigger") && info.muleInfo.hasOwnProperty("usedInventoryTrigger") &&
 					Storage.Inventory.UsedSpacePercent() >= info.muleInfo.usedInventoryTrigger && Storage.Stash.UsedSpacePercent() >= info.muleInfo.usedStashTrigger &&
 						items.length > 0) {

--- a/d2bs/kolbot/libs/AutoMule.js
+++ b/d2bs/kolbot/libs/AutoMule.js
@@ -361,6 +361,10 @@ MainLoop:
 		} else {
 			print("ÿc4AutoMuleÿc0: In mule game.");
 			D2Bot.updateStatus("AutoMule: In game.");
+			if (Config.LowGold > 0) {
+				Town.doChores();
+				Town.goToTown(1);
+			}
 			this.dropStuff();
 		}
 


### PR DESCRIPTION
When lowGold is set the bot will pick up junk to sell, and this will
trigger muling if muling conditions are met. The junk will then end up
being muled along with real drops.

This change makes the bot sell the junk before muling.