### PR TITLE
Add UseRedemption option to Nihlathak script

### DIFF
--- a/d2bs/kolbot/libs/bots/Nihlathak.js
+++ b/d2bs/kolbot/libs/bots/Nihlathak.js
@@ -9,6 +9,16 @@ function Nihlathak() {
 	Pather.useWaypoint(123);
 	Precast.doPrecast(false);
 
+	let skillBackup1, skillBackup2;
+	if (Config.Nihlathak.UseRedemption && me.classid === 3 && me.getSkill(124, 0)) {
+		skillBackup1 = Config.AttackSkill[2];
+		skillBackup2 = Config.AttackSkill[4];
+		Config.AttackSkill[2] = 124;
+		Config.AttackSkill[4] = 124;
+
+		Attack.init();
+	}
+
 	if (!Pather.moveToExit(124, true)) {
 		throw new Error("Failed to go to Nihlathak");
 	}
@@ -22,6 +32,14 @@ function Nihlathak() {
 	}
 
 	Attack.kill(526); // Nihlathak
+
+	if (skillBackup1) {
+		Config.AttackSkill[2] = skillBackup1;
+		Config.AttackSkill[4] = skillBackup2;
+
+		Attack.init();
+	}
+
 	Pickit.pickItems();
 
 	return true;

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -346,7 +346,8 @@ var Config = {
 		ViperQuit: false
 	},
 	Nihlathak: {
-		ViperQuit: false
+		ViperQuit: false,
+		UseRedemption: false,
 	},
 	Pit: {
 		ClearPath: false,

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -101,6 +101,7 @@ function LoadConfig() {
 		Config.Pindleskin.ViperQuit = false; // End script if Tomb Vipers are found.
 	Scripts.Nihlathak = false;
 		Config.Nihlathak.ViperQuit = false; // End script if Tomb Vipers are found.
+		Config.Nihlathak.UseRedemption = false; // Use redemption to counter corpse explosion
 	Scripts.Eldritch = false;
 		Config.Eldritch.OpenChest = true;
 		Config.Eldritch.KillShenk = true;


### PR DESCRIPTION
Corpse explosion is a killer

Note: Adding as a draft as I'd love some feedback on this approach before committing. It seems to work fine except when `WalkClear` is set. With `WalkClear` set, Nihlathak isn't "targeted" and is just killed during clearing the area, and redemption is never activated.