### PR TITLE
BreakClearLevel fix

### DIFF
--- a/d2bs/kolbot/libs/bots/MFHelper.js
+++ b/d2bs/kolbot/libs/bots/MFHelper.js
@@ -101,6 +101,7 @@ function MFHelper() {
 	addEventListener("chatmsg", ChatEvent);
 	Town.doChores();
 	Town.move("portalspot");
+	Config.MFHelper.BreakClearLevel = true; // overwrite Config.js value
 
 	if (Config.Leader) {
 		for (i = 0; i < 30; i += 1) {
@@ -236,5 +237,6 @@ MainLoop:
 		delay(100);
 	}
 
+	Config.MFHelper.BreakClearLevel = false; // revert to default value
 	return true;
 }

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -436,7 +436,7 @@ var Config = {
 		RecheckSeals: false
 	},
 	MFHelper: {
-		BreakClearLevel: true
+		BreakClearLevel: false
 	},
 	Wakka: {
 		Wait: 1


### PR DESCRIPTION
BreakClearing only in the case of MFHelper
additional fix for https://github.com/blizzhackers/kolbot/pull/31