### PR TITLE
enable picking in manual play + minor changes

### DIFF
--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -48,7 +48,7 @@ function main() {
 			load("tools/party.js");
 		}
 
-		if (Config.FastPick) {
+		if (Config.ManualPlayPick) {
 			load("tools/pickthread.js");
 		}
 

--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -40,9 +40,21 @@ function main() {
 
 	if (getScript("d2botmap.dbj")) {
 		load("tools/mapthread.js");
-		load("tools/ToolsThread.js");
+		load("tools/toolsthread.js");
 		Config.init(true);
 		LocalChat.init();
+
+		if (Config.PublicMode) {
+			load("tools/party.js");
+		}
+
+		if (Config.FastPick) {
+			load("tools/pickthread.js");
+		}
+
+		if (Config.AutoMap) {
+			me.automap = true;
+		}
 
 		while (true) {
 			delay(1000);

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -185,6 +185,7 @@ var Config = {
 	MakeRoom: true,
 	ClearInvOnStart: true,
 	FastPick: false,
+	ManualPlayPick: false,
 	OpenChests: false,
 	PickitFiles: [],
 	BeltColumn: [],

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -296,7 +296,8 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
+	Config.FastPick = false; // Check and pick items between attacks
+	Config.ManualPlayPick = false; // If set to true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.

--- a/d2bs/kolbot/libs/config/Amazon.js
+++ b/d2bs/kolbot/libs/config/Amazon.js
@@ -212,7 +212,7 @@ function LoadConfig() {
 		Config.ChestMania.Act1 = [13, 14, 15, 16, 18, 19]; // List of act 1 areas to open chests in
 		Config.ChestMania.Act2 = [55, 59, 65, 66, 67, 68, 69, 70, 71, 72]; // List of act 2 areas to open chests in
 		Config.ChestMania.Act3 = [79, 80, 81, 92, 93, 84, 85, 90]; // List of act 3 areas to open chests in
-		Config.ChestMania.Act4 = []; // List of act 4 areas to open chests in
+		Config.ChestMania.Act4 = [107]; // List of act 4 areas to open chests in
 		Config.ChestMania.Act5 = [115, 116, 119, 125, 126, 127]; // List of act 5 areas to open chests in
 	Scripts.ClearAnyArea = false; // Clear any area. Uses Config.ClearType to determine which type of monsters to kill.
 		Config.ClearAnyArea.AreaList = []; // List of area ids to clear. See sdk/areas.txt
@@ -296,7 +296,7 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks
+	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.
@@ -426,8 +426,8 @@ function LoadConfig() {
 	Config.LocalChat.Enabled = false; // enable the LocalChat system
 	Config.LocalChat.Toggle = false; // optional, set to KEY value to toggle through modes 0, 1, 2
 	Config.LocalChat.Mode = 0; // 0 = disabled, 1 = chat from 'say' (recommended), 2 = all chat (for manual play)
-	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 
+	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 	// If set on true, it simply parties.
 	Config.PublicMode = 0; // 1 = invite and accept, 2 = accept only, 3 = invite only, 0 = disable.
 

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -296,7 +296,8 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
+	Config.FastPick = false; // Check and pick items between attacks
+	Config.ManualPlayPick = false; // If set to true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.

--- a/d2bs/kolbot/libs/config/Assassin.js
+++ b/d2bs/kolbot/libs/config/Assassin.js
@@ -212,7 +212,7 @@ function LoadConfig() {
 		Config.ChestMania.Act1 = [13, 14, 15, 16, 18, 19]; // List of act 1 areas to open chests in
 		Config.ChestMania.Act2 = [55, 59, 65, 66, 67, 68, 69, 70, 71, 72]; // List of act 2 areas to open chests in
 		Config.ChestMania.Act3 = [79, 80, 81, 92, 93, 84, 85, 90]; // List of act 3 areas to open chests in
-		Config.ChestMania.Act4 = []; // List of act 4 areas to open chests in
+		Config.ChestMania.Act4 = [107]; // List of act 4 areas to open chests in
 		Config.ChestMania.Act5 = [115, 116, 119, 125, 126, 127]; // List of act 5 areas to open chests in
 	Scripts.ClearAnyArea = false; // Clear any area. Uses Config.ClearType to determine which type of monsters to kill.
 		Config.ClearAnyArea.AreaList = []; // List of area ids to clear. See sdk/areas.txt
@@ -296,7 +296,7 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks
+	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.
@@ -426,8 +426,8 @@ function LoadConfig() {
 	Config.LocalChat.Enabled = false; // enable the LocalChat system
 	Config.LocalChat.Toggle = false; // optional, set to KEY value to toggle through modes 0, 1, 2
 	Config.LocalChat.Mode = 0; // 0 = disabled, 1 = chat from 'say' (recommended), 2 = all chat (for manual play)
-	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 
+	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 	// If set on true, it simply parties.
 	Config.PublicMode = 0; // 1 = invite and accept, 2 = accept only, 3 = invite only, 0 = disable.
 

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -296,7 +296,8 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
+	Config.FastPick = false; // Check and pick items between attacks
+	Config.ManualPlayPick = false; // If set to true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.

--- a/d2bs/kolbot/libs/config/Barbarian.js
+++ b/d2bs/kolbot/libs/config/Barbarian.js
@@ -212,7 +212,7 @@ function LoadConfig() {
 		Config.ChestMania.Act1 = [13, 14, 15, 16, 18, 19]; // List of act 1 areas to open chests in
 		Config.ChestMania.Act2 = [55, 59, 65, 66, 67, 68, 69, 70, 71, 72]; // List of act 2 areas to open chests in
 		Config.ChestMania.Act3 = [79, 80, 81, 92, 93, 84, 85, 90]; // List of act 3 areas to open chests in
-		Config.ChestMania.Act4 = []; // List of act 4 areas to open chests in
+		Config.ChestMania.Act4 = [107]; // List of act 4 areas to open chests in
 		Config.ChestMania.Act5 = [115, 116, 119, 125, 126, 127]; // List of act 5 areas to open chests in
 	Scripts.ClearAnyArea = false; // Clear any area. Uses Config.ClearType to determine which type of monsters to kill.
 		Config.ClearAnyArea.AreaList = []; // List of area ids to clear. See sdk/areas.txt
@@ -296,7 +296,7 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks
+	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.
@@ -426,8 +426,8 @@ function LoadConfig() {
 	Config.LocalChat.Enabled = false; // enable the LocalChat system
 	Config.LocalChat.Toggle = false; // optional, set to KEY value to toggle through modes 0, 1, 2
 	Config.LocalChat.Mode = 0; // 0 = disabled, 1 = chat from 'say' (recommended), 2 = all chat (for manual play)
-	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 
+	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 	// If set on true, it simply parties.
 	Config.PublicMode = 0; // 1 = invite and accept, 2 = accept only, 3 = invite only, 0 = disable.
 

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -296,7 +296,8 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
+	Config.FastPick = false; // Check and pick items between attacks
+	Config.ManualPlayPick = false; // If set to true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.

--- a/d2bs/kolbot/libs/config/Druid.js
+++ b/d2bs/kolbot/libs/config/Druid.js
@@ -212,7 +212,7 @@ function LoadConfig() {
 		Config.ChestMania.Act1 = [13, 14, 15, 16, 18, 19]; // List of act 1 areas to open chests in
 		Config.ChestMania.Act2 = [55, 59, 65, 66, 67, 68, 69, 70, 71, 72]; // List of act 2 areas to open chests in
 		Config.ChestMania.Act3 = [79, 80, 81, 92, 93, 84, 85, 90]; // List of act 3 areas to open chests in
-		Config.ChestMania.Act4 = []; // List of act 4 areas to open chests in
+		Config.ChestMania.Act4 = [107]; // List of act 4 areas to open chests in
 		Config.ChestMania.Act5 = [115, 116, 119, 125, 126, 127]; // List of act 5 areas to open chests in
 	Scripts.ClearAnyArea = false; // Clear any area. Uses Config.ClearType to determine which type of monsters to kill.
 		Config.ClearAnyArea.AreaList = []; // List of area ids to clear. See sdk/areas.txt
@@ -296,7 +296,7 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks
+	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.
@@ -426,8 +426,8 @@ function LoadConfig() {
 	Config.LocalChat.Enabled = false; // enable the LocalChat system
 	Config.LocalChat.Toggle = false; // optional, set to KEY value to toggle through modes 0, 1, 2
 	Config.LocalChat.Mode = 0; // 0 = disabled, 1 = chat from 'say' (recommended), 2 = all chat (for manual play)
-	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 
+	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 	// If set on true, it simply parties.
 	Config.PublicMode = 0; // 1 = invite and accept, 2 = accept only, 3 = invite only, 0 = disable.
 

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -296,7 +296,8 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
+	Config.FastPick = false; // Check and pick items between attacks
+	Config.ManualPlayPick = false; // If set to true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -212,7 +212,7 @@ function LoadConfig() {
 		Config.ChestMania.Act1 = [13, 14, 15, 16, 18, 19]; // List of act 1 areas to open chests in
 		Config.ChestMania.Act2 = [55, 59, 65, 66, 67, 68, 69, 70, 71, 72]; // List of act 2 areas to open chests in
 		Config.ChestMania.Act3 = [79, 80, 81, 92, 93, 84, 85, 90]; // List of act 3 areas to open chests in
-		Config.ChestMania.Act4 = []; // List of act 4 areas to open chests in
+		Config.ChestMania.Act4 = [107]; // List of act 4 areas to open chests in
 		Config.ChestMania.Act5 = [115, 116, 119, 125, 126, 127]; // List of act 5 areas to open chests in
 	Scripts.ClearAnyArea = false; // Clear any area. Uses Config.ClearType to determine which type of monsters to kill.
 		Config.ClearAnyArea.AreaList = []; // List of area ids to clear. See sdk/areas.txt
@@ -296,7 +296,7 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks
+	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.
@@ -426,8 +426,8 @@ function LoadConfig() {
 	Config.LocalChat.Enabled = false; // enable the LocalChat system
 	Config.LocalChat.Toggle = false; // optional, set to KEY value to toggle through modes 0, 1, 2
 	Config.LocalChat.Mode = 0; // 0 = disabled, 1 = chat from 'say' (recommended), 2 = all chat (for manual play)
-	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 
+	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 	// If set on true, it simply parties.
 	Config.PublicMode = 0; // 1 = invite and accept, 2 = accept only, 3 = invite only, 0 = disable.
 

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -296,7 +296,8 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
+	Config.FastPick = false; // Check and pick items between attacks
+	Config.ManualPlayPick = false; // If set to true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.

--- a/d2bs/kolbot/libs/config/Paladin.js
+++ b/d2bs/kolbot/libs/config/Paladin.js
@@ -212,7 +212,7 @@ function LoadConfig() {
 		Config.ChestMania.Act1 = [13, 14, 15, 16, 18, 19]; // List of act 1 areas to open chests in
 		Config.ChestMania.Act2 = [55, 59, 65, 66, 67, 68, 69, 70, 71, 72]; // List of act 2 areas to open chests in
 		Config.ChestMania.Act3 = [79, 80, 81, 92, 93, 84, 85, 90]; // List of act 3 areas to open chests in
-		Config.ChestMania.Act4 = []; // List of act 4 areas to open chests in
+		Config.ChestMania.Act4 = [107]; // List of act 4 areas to open chests in
 		Config.ChestMania.Act5 = [115, 116, 119, 125, 126, 127]; // List of act 5 areas to open chests in
 	Scripts.ClearAnyArea = false; // Clear any area. Uses Config.ClearType to determine which type of monsters to kill.
 		Config.ClearAnyArea.AreaList = []; // List of area ids to clear. See sdk/areas.txt
@@ -296,7 +296,7 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks
+	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.
@@ -426,8 +426,8 @@ function LoadConfig() {
 	Config.LocalChat.Enabled = false; // enable the LocalChat system
 	Config.LocalChat.Toggle = false; // optional, set to KEY value to toggle through modes 0, 1, 2
 	Config.LocalChat.Mode = 0; // 0 = disabled, 1 = chat from 'say' (recommended), 2 = all chat (for manual play)
-	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 
+	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 	// If set on true, it simply parties.
 	Config.PublicMode = 0; // 1 = invite and accept, 2 = accept only, 3 = invite only, 0 = disable.
 

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -296,7 +296,8 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
+	Config.FastPick = false; // Check and pick items between attacks
+	Config.ManualPlayPick = false; // If set to true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -212,7 +212,7 @@ function LoadConfig() {
 		Config.ChestMania.Act1 = [13, 14, 15, 16, 18, 19]; // List of act 1 areas to open chests in
 		Config.ChestMania.Act2 = [55, 59, 65, 66, 67, 68, 69, 70, 71, 72]; // List of act 2 areas to open chests in
 		Config.ChestMania.Act3 = [79, 80, 81, 92, 93, 84, 85, 90]; // List of act 3 areas to open chests in
-		Config.ChestMania.Act4 = []; // List of act 4 areas to open chests in
+		Config.ChestMania.Act4 = [107]; // List of act 4 areas to open chests in
 		Config.ChestMania.Act5 = [115, 116, 119, 125, 126, 127]; // List of act 5 areas to open chests in
 	Scripts.ClearAnyArea = false; // Clear any area. Uses Config.ClearType to determine which type of monsters to kill.
 		Config.ClearAnyArea.AreaList = []; // List of area ids to clear. See sdk/areas.txt
@@ -296,7 +296,7 @@ function LoadConfig() {
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks
+	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.
@@ -426,8 +426,8 @@ function LoadConfig() {
 	Config.LocalChat.Enabled = false; // enable the LocalChat system
 	Config.LocalChat.Toggle = false; // optional, set to KEY value to toggle through modes 0, 1, 2
 	Config.LocalChat.Mode = 0; // 0 = disabled, 1 = chat from 'say' (recommended), 2 = all chat (for manual play)
-	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 
+	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 	// If set on true, it simply parties.
 	Config.PublicMode = 0; // 1 = invite and accept, 2 = accept only, 3 = invite only, 0 = disable.
 

--- a/d2bs/kolbot/libs/config/_BaseConfigFile.js
+++ b/d2bs/kolbot/libs/config/_BaseConfigFile.js
@@ -202,7 +202,7 @@
 		Config.ChestMania.Act1 = [13, 14, 15, 16, 18, 19]; // List of act 1 areas to open chests in
 		Config.ChestMania.Act2 = [55, 59, 65, 66, 67, 68, 69, 70, 71, 72]; // List of act 2 areas to open chests in
 		Config.ChestMania.Act3 = [79, 80, 81, 92, 93, 84, 85, 90]; // List of act 3 areas to open chests in
-		Config.ChestMania.Act4 = []; // List of act 4 areas to open chests in
+		Config.ChestMania.Act4 = [107]; // List of act 4 areas to open chests in
 		Config.ChestMania.Act5 = [115, 116, 119, 125, 126, 127]; // List of act 5 areas to open chests in
 	Scripts.ClearAnyArea = false; // Clear any area. Uses Config.ClearType to determine which type of monsters to kill.
 		Config.ClearAnyArea.AreaList = []; // List of area ids to clear. See sdk/areas.txt
@@ -300,7 +300,7 @@
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks
+	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.
@@ -543,8 +543,8 @@
 	Config.LocalChat.Enabled = false; // enable the LocalChat system
 	Config.LocalChat.Toggle = false; // optional, set to KEY value to toggle through modes 0, 1, 2
 	Config.LocalChat.Mode = 0; // 0 = disabled, 1 = chat from 'say' (recommended), 2 = all chat (for manual play)
-	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 
+	// If Config.Leader is set, the bot will only accept invites from leader. If Config.PublicMode is not 0, Baal and Diablo script will open Town Portals.
 	// If set on true, it simply parties.
 	Config.PublicMode = 0; // 1 = invite and accept, 2 = accept only, 3 = invite only, 0 = disable.
 

--- a/d2bs/kolbot/libs/config/_BaseConfigFile.js
+++ b/d2bs/kolbot/libs/config/_BaseConfigFile.js
@@ -519,7 +519,7 @@
 	Config.Runewords.push([Runeword.CallToArms, "Phase Blade"]); // Make CTA Phase Blade
 	//Config.Runewords.push([Runeword.CallToArms, "Flail"]); // Make CTA Flail
 	//Config.KeepRunewords.push("[name] == crystalsword || [name] == phaseblade || [name] == flail # [plusskillbattlecommand] >= 3 && [plusskillbattleorders] >=3");
-	Config.KeepRunewords.push("[name] == crystalsword || [name] == phaseblade || [name] == flail # [plusskillbattlecommand] >= 6 && [plusskillbattleorders] >=6 && ["plusskillbattlecry"] >= 4"); // perfect CTA and *optional [enhanceddamage] = 290%
+	Config.KeepRunewords.push("[name] == crystalsword || [name] == phaseblade || [name] == flail # [plusskillbattlecommand] >= 6 && [plusskillbattleorders] >=6 && [plusskillbattlecry] >= 4"); // perfect CTA and *optional [enhanceddamage] = 290%
 
 	Config.Runewords.push([Runeword.Spirit, "Crystal Sword"]); // Make Spirit Crystal Sword
 	Config.Runewords.push([Runeword.Spirit, "Broad Sword"]); // Make Spirit Broad Sword

--- a/d2bs/kolbot/libs/config/_BaseConfigFile.js
+++ b/d2bs/kolbot/libs/config/_BaseConfigFile.js
@@ -300,7 +300,8 @@
 	Config.PickitFiles.push("kolton.nip");
 	Config.PickitFiles.push("LLD.nip");
 	Config.PickRange = 40; // Pick radius
-	Config.FastPick = false; // Check and pick items between attacks. If true and D2BotMap entry script is used, will enable picking in manual play.
+	Config.FastPick = false; // Check and pick items between attacks
+	Config.ManualPlayPick = false; // If set to true and D2BotMap entry script is used, will enable picking in manual play.
 
 	/* Advanced automule settings
 	 * Trigger - Having an item that is on the list will initiate muling. Useful if you want to mule something immediately upon finding.

--- a/d2bs/kolbot/tools/PickThread.js
+++ b/d2bs/kolbot/tools/PickThread.js
@@ -1,0 +1,59 @@
+/**
+*	@filename	PickThread.js
+*	@author		stffdtiger
+*	@desc		a loop that runs Pickit.FastPick() intended to be used with D2BotMap entry script
+*/
+
+js_strict(true);
+
+include("json2.js");
+include("NTItemParser.dbl");
+include("OOG.js");
+include("CraftingSystem.js");
+include("common/Cubing.js");
+include("common/CollMap.js");
+include("common/Config.js");
+include("common/misc.js");
+include("common/util.js");
+include("common/Pickit.js");
+include("common/Pather.js");
+include("common/Prototypes.js");
+include("common/Runewords.js");
+include("common/Storage.js");
+include("common/Town.js");
+
+function main() {
+	print("ÿc9Pick Thread Loaded.");
+	Config.init(false);
+	Pickit.init(false);
+	Storage.Init();
+	CraftingSystem.buildLists();
+	Runewords.init();
+	Cubing.init();
+
+	var ii, noPick = false,
+		UIFlagList = [0x01, 0x02, 0x03, 0x04, 0x05, 0x09, 0x0B, 0x0E, 0x0F, 0x14, 0x16, 0x1A, 0x24];
+
+	this.itemEvent = function (gid, mode, code, global) {
+		if (gid > 0 && mode === 0) {
+			Pickit.gidList.push(gid);
+		}
+	};
+
+	addEventListener("itemaction", this.itemEvent);
+
+	while (true) {
+		for (ii = 0 ; ii < UIFlagList.length ; ii++) {
+			if (getUIFlag(UIFlagList[ii])) {
+				noPick = true;
+				break;
+			}
+		}
+		if (!me.inTown && !noPick) {
+			Pickit.fastPick();
+		}
+		noPick = false;
+		delay(50);
+	}
+	return true;
+}


### PR DESCRIPTION
`PickThread.js`
* code to call `Pickit.FastPick()`.

`default.dbj`
* add loading of `PickThread.js`.
* add use of `Config.AutoMap` and `Config.PublicMode` when using D2BotMap.

`Config.js`
* add `ManualPlayPick` option.

`[Character].js`
* add `Config.ManualPlayPick` option.
* add river of flame to `Config.ChestMania.Act4`.

`_BaseConfigFile.js`
* add `Config.ManualPlayPick` option.
* add river of flame to `Config.ChestMania.Act4`.
* fix an error in a kept runeword (CTA).