### PR TITLE
Require.js upgrades

### DIFF
--- a/d2bs/kolbot/libs/require.js
+++ b/d2bs/kolbot/libs/require.js
@@ -9,22 +9,37 @@
 typeof global === 'undefined' && (this['global'] = this);
 
 global['module'] = {exports: undefined};
+global['exports'] = {};
+function removeRelativePath(test) {
+	print('here -> '+ test.replace(/\\/g, '/'));
+	return test.replace(/\\/g, '/').split('/').reduce(function (acc, cur) {
+		if (!cur || cur === '.') return acc;
+		if (cur === '..') {
+			acc.pop();
+			return acc;
+		}
+		acc.push(cur);
+		return acc;
+
+	}, []).join('/');
+}
 global.require = (function (include, isIncluded, print, notify) {
+
 
 	let depth = 0;
 	const modules = {};
 	const obj = function require(field, path) {
 		const stack = new Error().stack.match(/[^\r\n]+/g);
-		let directory = stack[1].match(/.*?@.*?d2bs\\(kolbot\\?.*)\\.*(\.js|\.dbj):/)[1].replace('\\','/')+'/';
+		let directory = stack[1].match(/.*?@.*?d2bs\\(kolbot\\?.*)\\.*(\.js|\.dbj):/)[1].replace('\\', '/') + '/';
 		let filename = stack[1].match(/.*?@.*?d2bs\\kolbot\\?(.*)(\.js|\.dbj):/)[1];
-		filename = filename.substr(filename.length-filename.split('').reverse().join('').indexOf('\\'));
+		filename = filename.substr(filename.length - filename.split('').reverse().join('').indexOf('\\'));
 		// remove the name kolbot of the file
 		if (directory.startsWith('kolbot')) {
-			directory =  directory.substr('kolbot'.length);
+			directory = directory.substr('kolbot'.length);
 		}
 
 		// remove the / from it
-		if (directory.startsWith('/')){
+		if (directory.startsWith('/')) {
 			directory = directory.substr(1);
 		}
 
@@ -32,28 +47,33 @@ global.require = (function (include, isIncluded, print, notify) {
 		if (directory.startsWith('lib')) {
 			directory = directory.substr(4);
 		} else {
-			directory = '../'+directory; // Add a extra recursive path, as we start out of the lib directory
+			directory = '../' + directory; // Add a extra recursive path, as we start out of the lib directory
 		}
 
-		const asNew = this.__proto__.constructor === require && ((...args) => new (Function.prototype.bind.apply(modules[packageName].exports, args)));
 
 		path = path || directory;
-		const packageName = (path + field).replace(/[^a-z0-9]/gi, '_').toLowerCase();
+
+		const fullpath = removeRelativePath((path + field).replace(/\\/, '/')).toLowerCase();
+		const packageName = fullpath;
+
+		const asNew = this.__proto__.constructor === require && ((...args) => new (Function.prototype.bind.apply(modules[packageName].exports, args)));
 
 		if (field.hasOwnProperty('endsWith') && field.endsWith('.json')) { // Simply reads a json file
 			return modules[packageName] = File.open('libs/' + path + field, 0).readAllLines();
 		}
 
-		const fullpath = (path + field).replace(/\\/,'/');
 		const moduleNameShort = (fullpath + '.js').match(/.*?\/(\w*).js$/)[1];
 
 		if (!isIncluded(fullpath + '.js') && !modules.hasOwnProperty(moduleNameShort)) {
-			depth && notify && print('ÿc2Kolbotÿc0 ::    - loading dependency of '+filename+': ' +moduleNameShort);
+			depth && notify && print('ÿc2Kolbotÿc0 ::    - loading dependency of ' + filename + ': ' + moduleNameShort);
 			!depth && notify && print('ÿc2Kolbotÿc0 :: Loading module: ' + moduleNameShort);
 
-			let old = Object.create(global['module']);
+			let oldModule = Object.create(global['module']);
+			let oldExports = Object.create(global['exports']);
 			delete global['module'];
-			global['module'] = {exports: undefined};
+			delete global['exports'];
+			global['module'] = {exports: null};
+			global['exports'] = {};
 
 			// Include the file;
 			try {
@@ -65,16 +85,21 @@ global.require = (function (include, isIncluded, print, notify) {
 				depth--
 			}
 
-			modules[moduleNameShort] = Object.create(global['module']);
-			delete global['module'];
+			if (!global['module']['exports'] && Object.keys(global['exports'])) { // Incase its transpiled typescript
+				global['module']['exports'] = global['exports'];
+			}
 
-			global['module'] = old;
+			modules[packageName] = Object.create(global['module']);
+			delete global['module'];
+			delete global['exports'];
+			global['module'] = oldModule;
+			global['exports'] = oldExports;
 		}
 
-		if (!modules.hasOwnProperty(moduleNameShort)) throw Error('unexpected module error -- ' + field);
+		if (!modules.hasOwnProperty(packageName)) throw Error('unexpected module error -- ' + field);
 
 		// If called as "new", fake an constructor
-		return asNew || modules[moduleNameShort].exports;
+		return asNew || modules[packageName].exports;
 	};
 	obj.modules = modules;
 	return obj;


### PR DESCRIPTION
- Works with typescript transpiled modules
- Calculates correctly the relative path of the module, so modules can have the same name `..\Sorc` and `..\bots\Sorc` do not conflict anymore
- more inline with modern require's possibilities with module's `exports` variable, which overrides `module.exports`
