### PR TITLE
Require.js more informative error throwing

### DIFF
--- a/d2bs/kolbot/libs/require.js
+++ b/d2bs/kolbot/libs/require.js
@@ -78,7 +78,16 @@ global.require = (function (include, isIncluded, print, notify) {
 			try {
 				depth++;
 				if (!include(fullpath + '.js')) {
-					throw Error('module ' + fullpath + ' not found');
+					const err = new Error('module ' + fullpath + ' not found');
+
+					// Rewrite the location of the error, to be more clear for the developer/user _where_ it crashes
+					const myStack = err.stack.match(/[^\r\n]+/g);
+					err.fileName = directory + myStack[1].match(/.*?@.*?d2bs\\kolbot\\?(.*)(\.js|\.dbj):/)[1];
+					err.lineNumber = myStack[1].substr(stack[1].lastIndexOf(':') + 1);
+					myStack.unshift();
+					err.stack = myStack.join('\r\n'); // rewrite stack
+
+					throw err;
 				}
 			} finally {
 				depth--


### PR DESCRIPTION
Instead of telling the end user/developer its failing on line 81 of require.js, it rewrites the stack and history of the generated error, and tells appears as if its thrown on the line where `require` is called.

This makes it allot more easy to debug