### PR TITLE
add some missing location handling in entry scripts

### DIFF
--- a/d2bs/kolbot/D2BotChannel.dbj
+++ b/d2bs/kolbot/D2BotChannel.dbj
@@ -16,6 +16,7 @@ var StarterConfig = {
 	CrashDelay: 60, // Seconds to wait after a d2 window crash
 	RealmDownDelay: 10, // Minutes to wait after getting Realm Down message
 	UnableToConnectDelay: 5, // Minutes to wait after Unable To Connect message
+	TCPIPNoHostDelay: 5, // Seconds to wait after Cannot Connect To Server message
 	CDKeyInUseDelay: 5, // Minutes to wait before connecting again if CD-Key is in use. SwitchKeys overrides this!
 	ConnectingTimeout: 20, // Seconds to wait before cancelling the 'Connecting...' screen
 	PleaseWaitTimeout: 10, // Seconds to wait before cancelling the 'Please Wait...' screen
@@ -127,15 +128,6 @@ function ReceiveCopyData(mode, msg) {
 		}
 
 		break;
-	}
-}
-
-function timeoutDelay(text, time) {
-	var endTime = getTickCount() + time;
-
-	while (getTickCount() < endTime) {
-		D2Bot.updateStatus(text + " (" + Math.floor((endTime - getTickCount()) / 1000) + "s)");
-		delay(500);
 	}
 }
 
@@ -335,7 +327,7 @@ MainSwitch:
 
 			if (StarterConfig.SkipMutedKey) {
 				if (gameInfo.switchKeys) {
-					timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
+					ControlAction.timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
 					D2Bot.restart(true);
 				} else {
 					D2Bot.stop();
@@ -363,7 +355,7 @@ MainSwitch:
 			}
 
 			if (StarterConfig.FirstJoinMessage !== "" && !chatActionsDone) { // Added !chatActionsDone condition to prevent spam
-				timeoutDelay("Chat delay", StarterConfig.ChatActionsDelay * 1e3);
+				ControlAction.timeoutDelay("Chat delay", StarterConfig.ChatActionsDelay * 1e3);
 				sayMsg(StarterConfig.FirstJoinMessage);
 				delay(500);
 			}
@@ -480,9 +472,9 @@ MainLoop:
 
 			if (retry === 0 || lastGameStatus === "pending") { // Only delay on first join - the rest is handled by GameDoesNotExistTimeout. Any other case is instant fail (ie. full game).
 				if (typeof AdvancedConfig[me.profile] === "object" && typeof AdvancedConfig[me.profile].JoinDelay === "number") {
-					timeoutDelay("Custom Join Delay", AdvancedConfig[me.profile].JoinDelay * 1e3);
+					ControlAction.timeoutDelay("Custom Join Delay", AdvancedConfig[me.profile].JoinDelay * 1e3);
 				} else if (StarterConfig.JoinDelay) {
-					timeoutDelay("Join Game Delay", StarterConfig.JoinDelay * 1e3);
+					ControlAction.timeoutDelay("Join Game Delay", StarterConfig.JoinDelay * 1e3);
 				}
 			}
 
@@ -646,16 +638,14 @@ MainLoop:
 		D2Bot.updateStatus("Unable To Connect");
 
 		if (connectFail) {
-			timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
 
 			connectFail = false;
+		} else {
+			connectFail = true;
 		}
 
-		if (!ControlAction.click(6, 335, 450, 128, 35)) {
-			break;
-		}
-
-		connectFail = true;
+		ControlAction.click(6, 335, 450, 128, 35);
 
 		break;
 	case 13: // Realm Down - Character Select screen
@@ -667,12 +657,12 @@ MainLoop:
 		}
 
 		updateCount();
-		timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
+		ControlAction.timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
 		D2Bot.CDKeyRD();
 
 		if (gameInfo.switchKeys) {
 			D2Bot.printToConsole("Realm Down - Changing CD-Key");
-			timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
+			ControlAction.timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
 			D2Bot.restart(true);
 		}
 
@@ -810,7 +800,7 @@ MainLoop:
 		//D2Bot.printToConsole("Game doesn't exist");
 		ControlAction.click(6, 652, 469, 120, 20);
 		ControlAction.click(6, 433, 433, 96, 32);
-		timeoutDelay("Game doesn't exist", StarterConfig.GameDoesNotExistTimeout * 1e3);
+		ControlAction.timeoutDelay("Game doesn't exist", StarterConfig.GameDoesNotExistTimeout * 1e3);
 
 		lastGameStatus = "DNE";
 
@@ -821,6 +811,32 @@ MainLoop:
 		ControlAction.click(6, 433, 433, 96, 32);
 
 		lastGameStatus = "FULL";
+
+		break;
+	case 39: // Other Multiplayer
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 40: // TCP/IP Game
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 41: // TCP/IP Game - Enter Host IP
+		login(me.profile);
+
+		break;
+	case 44: // Unable To Connect TCP/IP
+		D2Bot.updateStatus("Unable To Connect TCP/IP");
+
+		if (connectFail) {
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.TCPIPNoHostDelay * 1e3);
+
+			connectFail = false;
+		} else {
+			connectFail = true;
+		}
+
+		ControlAction.click(6, 351, 337, 96, 32);
 
 		break;
 	default:

--- a/d2bs/kolbot/D2BotFollow.dbj
+++ b/d2bs/kolbot/D2BotFollow.dbj
@@ -9,6 +9,7 @@ var StarterConfig = {
 	CrashDelay: rand(120, 150), // Seconds to wait after a d2 window crash
 	RealmDownDelay: 3, // Minutes to wait after getting Realm Down message
 	UnableToConnectDelay: 5, // Minutes to wait after Unable To Connect message
+	TCPIPNoHostDelay: 5, // Seconds to wait after Cannot Connect To Server message
 	CDKeyInUseDelay: 5, // Minutes to wait before connecting again if CD-Key is in use. SwitchKeys overrides this!
 	ConnectingTimeout: 20, // Seconds to wait before cancelling the 'Connecting...' screen
 	PleaseWaitTimeout: 30, // Seconds to wait before cancelling the 'Please Wait...' screen
@@ -63,7 +64,6 @@ include("common/util.js");
 var i, j, gameInfo, joinInfo, gameStart, ingame, handle,
 	firstLogin, chatActionsDone, lastGameTick, connectFail,
 	gameCount = DataFile.getStats().runs + 1,
-	ftj = 0,
 	loginRetry = 0,
 	lastGameStatus = "ready",
 	leader = "",
@@ -612,9 +612,7 @@ JoinLoop2:
 			connectFail = true;
 		}
 
-		if (!ControlAction.click(6, 335, 450, 128, 35)) {
-			break;
-		}
+		ControlAction.click(6, 335, 450, 128, 35);
 
 		break;
 	case 13: // Realm Down - Character Select screen
@@ -772,12 +770,6 @@ JoinLoop2:
 		break;
 	case 28: // Lobby - Game Does Not Exist
 		D2Bot.printToConsole("Game doesn't exist");
-		ftj++;
-
-		if (ftj > 4) {
-			D2Bot.update("done", "D2BotFollow failed to join game!");
-			D2Bot.stop(me.profile,true);
-		}
 
 		if (gameInfo.rdBlocker) {
 			D2Bot.printToConsole(gameInfo.mpq + " is probably flagged.", 6);
@@ -801,10 +793,35 @@ JoinLoop2:
 		lastGameStatus = "ready";
 
 		break;
+	case 39: // Other Multiplayer
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 40: // TCP/IP Game
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 41: // TCP/IP Game - Enter Host IP
+		login(me.profile);
+
+		break;
+	case 44: // Unable To Connect TCP/IP
+		D2Bot.updateStatus("Unable To Connect TCP/IP");
+
+		if (connectFail) {
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.TCPIPNoHostDelay * 1e3);
+
+			connectFail = false;
+		} else {
+			connectFail = true;
+		}
+
+		ControlAction.click(6, 351, 337, 96, 32);
+
+		break;
 	default:
 		if (location !== undefined) {
 			D2Bot.printToConsole("Unhandled location " + location);
-			//takeScreenshot();
 			delay(500);
 			D2Bot.restart();
 		}

--- a/d2bs/kolbot/D2BotGameAction.dbj
+++ b/d2bs/kolbot/D2BotGameAction.dbj
@@ -5,6 +5,7 @@ var StarterConfig = {
 	CrashDelay: 60, // Seconds to wait after a d2 window crash
 	RealmDownDelay: 2, // Minutes to wait after getting Realm Down message
 	UnableToConnectDelay: 5, // Minutes to wait after Unable To Connect message
+	TCPIPNoHostDelay: 5, // Seconds to wait after Cannot Connect To Server message
 	CDKeyInUseDelay: 5, // Minutes to wait before connecting again if CD-Key is in use. SwitchKeys overrides this!
 	ConnectingTimeout: 20, // Seconds to wait before cancelling the 'Connecting...' screen
 	PleaseWaitTimeout: 10, // Seconds to wait before cancelling the 'Please Wait...' screen
@@ -56,15 +57,6 @@ function ReceiveCopyData(mode, msg) {
 		tag = JSON.parse(msg).Tag;
 
 		break;
-	}
-}
-
-function timeoutDelay(text, time) {
-	var endTime = getTickCount() + time;
-
-	while (getTickCount() < endTime) {
-		D2Bot.updateStatus(text + " (" + Math.floor((endTime - getTickCount()) / 1000) + "s)");
-		delay(500);
 	}
 }
 
@@ -173,7 +165,7 @@ MainSwitch:
 
 		if (ingame) {
 			if (getTickCount() - gameStart < StarterConfig.MinGameTime * 1e3) {
-				timeoutDelay("Min game time wait", StarterConfig.MinGameTime * 1e3 + gameStart - getTickCount());
+				ControlAction.timeoutDelay("Min game time wait", StarterConfig.MinGameTime * 1e3 + gameStart - getTickCount());
 			}
 
 			print("updating runs");
@@ -376,16 +368,14 @@ MainSwitch:
 		D2Bot.updateStatus("Unable To Connect");
 
 		if (connectFail) {
-			timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
 
 			connectFail = false;
+		} else {
+			connectFail = true;
 		}
 
-		if (!ControlAction.click(6, 335, 450, 128, 35)) {
-			break;
-		}
-
-		connectFail = true;
+		ControlAction.click(6, 335, 450, 128, 35);
 
 		break;
 	case 12: // Character Select
@@ -432,11 +422,11 @@ MainSwitch:
 		}
 
 		updateCount();
-		timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
+		ControlAction.timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
 
 		if (gameInfo.switchKeys) {
 			D2Bot.printToConsole("Realm Down - Changing CD-Key");
-			timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
+			ControlAction.timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
 			D2Bot.restart(true);
 		} else {
 			D2Bot.restart();
@@ -599,6 +589,32 @@ MainSwitch:
 			GameAction.update("done", "Account has no chars! location 42");
 			D2Bot.stop(me.profile,true);
 		}
+
+		break;
+	case 39: // Other Multiplayer
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 40: // TCP/IP Game
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 41: // TCP/IP Game - Enter Host IP
+		login(me.profile);
+
+		break;
+	case 44: // Unable To Connect TCP/IP
+		D2Bot.updateStatus("Unable To Connect TCP/IP");
+
+		if (connectFail) {
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.TCPIPNoHostDelay * 1e3);
+
+			connectFail = false;
+		} else {
+			connectFail = true;
+		}
+
+		ControlAction.click(6, 351, 337, 96, 32);
 
 		break;
 	default:

--- a/d2bs/kolbot/D2BotLead.dbj
+++ b/d2bs/kolbot/D2BotLead.dbj
@@ -909,11 +909,11 @@ MainSwitch:
 		// doesn't happen when making
 		break;
 	case 39: // Other Multiplayer
-		sendKey(0x1B);
+		sendKey(0x1B); // Esc key
 
 		break;
 	case 40: // TCP/IP Game
-		sendKey(0x1B);
+		sendKey(0x1B); // Esc key
 
 		break;
 	default:

--- a/d2bs/kolbot/D2BotLead.dbj
+++ b/d2bs/kolbot/D2BotLead.dbj
@@ -17,6 +17,7 @@ var StarterConfig = {
 	FTJDelay: 10, // Seconds to wait after failing to create a game
 	RealmDownDelay: 3, // Minutes to wait after getting Realm Down message
 	UnableToConnectDelay: 5, // Minutes to wait after Unable To Connect message
+	TCPIPNoHostDelay: 5, // Seconds to wait after Cannot Connect To Server message
 	CDKeyInUseDelay: 5, // Minutes to wait before connecting again if CD-Key is in use.
 	ConnectingTimeout: 20, // Seconds to wait before cancelling the 'Connecting...' screen
 	PleaseWaitTimeout: 10, // Seconds to wait before cancelling the 'Please Wait...' screen
@@ -80,7 +81,6 @@ var gameInfo, gameStart, ingame, chatActionsDone, pingQuit,
 	handle, useChat, firstLogin, connectFail,
 	gameCount = DataFile.getStats().runs + 1,
 	loginRetry = 0,
-	ftj = 0,
 	lastGameStatus = "ready",
 	isUp = "no",
 	chanInfo = {
@@ -546,17 +546,11 @@ MainSwitch:
 
 		// FTJ handler
 		if (lastGameStatus === "pending") {
-			ftj++;
 			isUp = "no";
 
 			D2Bot.printToConsole("Failed to create game");
 			ControlAction.timeoutDelay("FTJ delay", StarterConfig.FTJDelay * 1e3);
 			D2Bot.updateRuns();
-
-			if (ftj > 4) {
-				D2Bot.update("done", "D2BotLead failed to join game!");
-				D2Bot.stop(me.profile,true);
-			}
 		}
 
 		ControlAction.createGame((gameInfo.gameName === "?" ? randomString(null,true) : gameInfo.gameName + gameCount), (gameInfo.gamePass === "?" ? randomString(null,true) : gameInfo.gamePass), gameInfo.difficulty, StarterConfig.CreateGameDelay * 1000);
@@ -721,13 +715,11 @@ MainSwitch:
 			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
 
 			connectFail = false;
+		} else {
+			connectFail = true;
 		}
 
-		if (!ControlAction.click(6, 335, 450, 128, 35)) {
-			break;
-		}
-
-		connectFail = true;
+		ControlAction.click(6, 335, 450, 128, 35);
 
 		break;
 	case 13: // Realm Down - Character Select screen
@@ -916,10 +908,27 @@ MainSwitch:
 		sendKey(0x1B); // Esc key
 
 		break;
+	case 41: // TCP/IP Game - Enter Host IP
+		login(me.profile);
+
+		break;
+	case 44: // Unable To Connect TCP/IP
+		D2Bot.updateStatus("Unable To Connect TCP/IP");
+
+		if (connectFail) {
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.TCPIPNoHostDelay * 1e3);
+
+			connectFail = false;
+		} else {
+			connectFail = true;
+		}
+
+		ControlAction.click(6, 351, 337, 96, 32);
+
+		break;
 	default:
 		if (location !== undefined) {
 			D2Bot.printToConsole("Unhandled location " + location);
-			//takeScreenshot();
 			delay(500);
 			D2Bot.restart();
 		}

--- a/d2bs/kolbot/D2BotLead.dbj
+++ b/d2bs/kolbot/D2BotLead.dbj
@@ -908,6 +908,14 @@ MainSwitch:
 	case 38: // Game is full
 		// doesn't happen when making
 		break;
+	case 39: // Other Multiplayer
+		sendKey(0x1B);
+
+		break;
+	case 40: // TCP/IP Game
+		sendKey(0x1B);
+
+		break;
 	default:
 		if (location !== undefined) {
 			D2Bot.printToConsole("Unhandled location " + location);

--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -4,6 +4,7 @@ var StarterConfig = {
 	SwitchKeyDelay: 0, // Seconds to wait before switching a used/banned key or after realm down
 	RealmDownDelay: 3, // Minutes to wait after getting Realm Down message
 	UnableToConnectDelay: 5, // Minutes to wait after Unable To Connect message
+	TCPIPNoHostDelay: 5, // Seconds to wait after Cannot Connect To Server message
 	CDKeyInUseDelay: 5, // Minutes to wait before connecting again if CD-Key is in use.
 	ConnectingTimeout: 20, // Seconds to wait before cancelling the 'Connecting...' screen
 	PleaseWaitTimeout: 10, // Seconds to wait before cancelling the 'Please Wait...' screen
@@ -334,15 +335,6 @@ function ingameTimeout(time) {
 	}
 
 	return me.ingame && me.gameReady;
-}
-
-function timeoutDelay(text, time) {
-	var endTime = getTickCount() + time;
-
-	while (getTickCount() < endTime) {
-		D2Bot.updateStatus(text + " (" + Math.floor((endTime - getTickCount()) / 1000) + "s)");
-		delay(500);
-	}
 }
 
 function updateCount() {
@@ -779,16 +771,14 @@ MainSwitch:
 		D2Bot.updateStatus("Unable To Connect");
 
 		if (connectFail) {
-			timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
 
 			connectFail = false;
+		} else {
+			connectFail = true;
 		}
 
-		if (!ControlAction.click(6, 335, 450, 128, 35)) {
-			break;
-		}
-
-		connectFail = true;
+		ControlAction.click(6, 335, 450, 128, 35);
 
 		break;
 	case 13: // Realm Down - Character Select screen
@@ -800,12 +790,12 @@ MainSwitch:
 		}
 
 		updateCount();
-		timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
+		ControlAction.timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
 		D2Bot.CDKeyRD();
 
 		if (gameInfo.switchKeys) {
 			D2Bot.printToConsole("Realm Down - Changing CD-Key");
-			timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
+			ControlAction.timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
 			D2Bot.restart(true);
 		} else {
 			D2Bot.restart();
@@ -870,12 +860,12 @@ MainSwitch:
 			}
 
 			updateCount();
-			timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
+			ControlAction.timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
 			D2Bot.CDKeyRD();
 
 			if (gameInfo.switchKeys) {
 				D2Bot.printToConsole("Realm Down - Changing CD-Key");
-				timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
+				ControlAction.timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
 				D2Bot.restart(true);
 			} else {
 				D2Bot.restart();
@@ -1045,5 +1035,39 @@ MainSwitch:
 		break;
 	case 38: // Game is full
 		break; // not sure how/if to handle
+	case 39: // Other Multiplayer
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 40: // TCP/IP Game
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 41: // TCP/IP Game - Enter Host IP
+		login(me.profile);
+
+		break;
+	case 44: // Unable To Connect TCP/IP
+		D2Bot.updateStatus("Unable To Connect TCP/IP");
+
+		if (connectFail) {
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.TCPIPNoHostDelay * 1e3);
+
+			connectFail = false;
+		} else {
+			connectFail = true;
+		}
+
+		ControlAction.click(6, 351, 337, 96, 32);
+
+		break;
+	default:
+		if (location !== undefined) {
+			D2Bot.printToConsole("Unhandled location " + location);
+			delay(500);
+			D2Bot.restart();
+		}
+
+		break;
 	}
 }

--- a/d2bs/kolbot/D2BotMuleLog.dbj
+++ b/d2bs/kolbot/D2BotMuleLog.dbj
@@ -7,6 +7,7 @@ var StarterConfig = {
 	CrashDelay: rand(60, 120), // Seconds to wait after a d2 window crash
 	RealmDownDelay: rand(3, 6), // Minutes to wait after getting Realm Down message
 	UnableToConnectDelay: rand(5, 8), // Minutes to wait after Unable To Connect message
+	TCPIPNoHostDelay: 5, // Seconds to wait after Cannot Connect To Server message
 	CDKeyInUseDelay: rand(5, 8), // Minutes to wait before connecting again if CD-Key is in use. SwitchKeys overrides this!
 	ConnectingTimeout: rand(20, 30), // Seconds to wait before cancelling the 'Connecting...' screen
 	PleaseWaitTimeout: rand(10, 20), // Seconds to wait before cancelling the 'Please Wait...' screen
@@ -65,15 +66,6 @@ function ReceiveCopyData(mode, msg) {
 		}
 
 		break;
-	}
-}
-
-function timeoutDelay(text, time) {
-	var endTime = getTickCount() + time;
-
-	while (getTickCount() < endTime) {
-		D2Bot.updateStatus(text + " (" + Math.floor((endTime - getTickCount()) / 1000) + "s)");
-		delay(500);
 	}
 }
 
@@ -183,7 +175,7 @@ MainSwitch:
 
 		if (ingame) {
 			if (getTickCount() - gameStart < StarterConfig.MinGameTime * 1e3) {
-				timeoutDelay("Min game time wait", StarterConfig.MinGameTime * 1e3 + gameStart - getTickCount());
+				ControlAction.timeoutDelay("Min game time wait", StarterConfig.MinGameTime * 1e3 + gameStart - getTickCount());
 			}
 
 			print("updating runs");
@@ -246,7 +238,7 @@ MainSwitch:
 			gameCount += 1;
 		}
 
-		timeoutDelay("Make Game Delay", StarterConfig.CreateGameDelay * 1e3);
+		ControlAction.timeoutDelay("Make Game Delay", StarterConfig.CreateGameDelay * 1e3);
 		createGame(MuleLogger.LogGame[0] + gameCount, MuleLogger.LogGame[1], 0);
 		locationTimeout(5000, location);
 
@@ -395,16 +387,14 @@ MainSwitch:
 		D2Bot.updateStatus("Unable To Connect");
 
 		if (connectFail) {
-			timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
 
 			connectFail = false;
+		} else {
+			connectFail = true;
 		}
 
-		if (!ControlAction.click(6, 335, 450, 128, 35)) {
-			break;
-		}
-
-		connectFail = true;
+		ControlAction.click(6, 335, 450, 128, 35);
 
 		break;
 	case 12: // Character Select
@@ -464,11 +454,11 @@ MainSwitch:
 		}
 
 		updateCount();
-		timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
+		ControlAction.timeoutDelay("Realm Down", StarterConfig.RealmDownDelay * 6e4);
 
 		if (gameInfo.switchKeys) {
 			D2Bot.printToConsole("Realm Down - Changing CD-Key");
-			timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
+			ControlAction.timeoutDelay("Key switch delay", StarterConfig.SwitchKeyDelay * 1000);
 			D2Bot.restart(true);
 		} else {
 			D2Bot.restart();
@@ -624,6 +614,32 @@ MainSwitch:
 
 			ControlAction.click(6, 33, 572, 128, 35);
 		}
+
+		break;
+	case 39: // Other Multiplayer
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 40: // TCP/IP Game
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 41: // TCP/IP Game - Enter Host IP
+		login(me.profile);
+
+		break;
+	case 44: // Unable To Connect TCP/IP
+		D2Bot.updateStatus("Unable To Connect TCP/IP");
+
+		if (connectFail) {
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.TCPIPNoHostDelay * 1e3);
+
+			connectFail = false;
+		} else {
+			connectFail = true;
+		}
+
+		ControlAction.click(6, 351, 337, 96, 32);
 
 		break;
 	default:

--- a/d2bs/kolbot/D2BotPubJoin.dbj
+++ b/d2bs/kolbot/D2BotPubJoin.dbj
@@ -16,6 +16,7 @@ var StarterConfig = {
 	FTJDelay: 10, // Seconds to wait after failing to create a game
 	RealmDownDelay: 2, // Minutes to wait after getting Realm Down message
 	UnableToConnectDelay: 5, // Minutes to wait after Unable To Connect message
+	TCPIPNoHostDelay: 5, // Seconds to wait after Cannot Connect To Server message
 	CDKeyInUseDelay: 5, // Minutes to wait before connecting again if CD-Key is in use.
 	ConnectingTimeout: 20, // Seconds to wait before cancelling the 'Connecting...' screen
 	PleaseWaitTimeout: 10, // Seconds to wait before cancelling the 'Please Wait...' screen
@@ -647,13 +648,11 @@ MainSwitch:
 			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.UnableToConnectDelay * 6e4);
 
 			connectFail = false;
+		} else {
+			connectFail = true;
 		}
 
-		if (!ControlAction.click(6, 335, 450, 128, 35)) {
-			break;
-		}
-
-		connectFail = true;
+		ControlAction.click(6, 335, 450, 128, 35);
 
 		break;
 	case 13: // Realm Down - Character Select screen
@@ -808,10 +807,35 @@ MainSwitch:
 	case 38: // Game is full
 		// doesn't happen when making
 		break;
+	case 39: // Other Multiplayer
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 40: // TCP/IP Game
+		sendKey(0x1B); // Esc key
+
+		break;
+	case 41: // TCP/IP Game - Enter Host IP
+		login(me.profile);
+
+		break;
+	case 44: // Unable To Connect TCP/IP
+		D2Bot.updateStatus("Unable To Connect TCP/IP");
+
+		if (connectFail) {
+			ControlAction.timeoutDelay("Unable to Connect", StarterConfig.TCPIPNoHostDelay * 1e3);
+
+			connectFail = false;
+		} else {
+			connectFail = true;
+		}
+
+		ControlAction.click(6, 351, 337, 96, 32);
+
+		break;
 	default:
 		if (location !== undefined) {
 			D2Bot.printToConsole("Unhandled location " + location);
-			//takeScreenshot();
 			delay(500);
 			D2Bot.restart();
 		}


### PR DESCRIPTION
* location 40 = TCP/IP Game menu
when hosting a TCP/IP game, after the game ends you land on location 40, but this wasn't handled before. just press Esc to go back to location 39.
* location 39 = Other Multiplayer menu
just press Esc to go back to Main Menu.