### PR TITLE
Let GameAction create games again

### DIFF
--- a/d2bs/kolbot/D2BotGameAction.dbj
+++ b/d2bs/kolbot/D2BotGameAction.dbj
@@ -241,6 +241,32 @@ MainSwitch:
 
 		break;
 	case 4: // Create Game
+		D2Bot.updateStatus("Creating Game");
+
+		control = getControl(1, 657, 342, 27, 20);
+
+		if (control && control.disabled === 5) {
+			ControlAction.click(6, 431, 341, 15, 16); // remove level restriction
+		}
+
+		if (gameCount >= 99) {
+			gameCount = 1;
+
+			DataFile.updateStats("runs", gameCount);
+		}
+
+		if (lastGameStatus === "pending") {
+			D2Bot.printToConsole("Failed to create game");
+
+			gameCount += 1;
+		}
+
+		timeoutDelay("Make Game Delay", StarterConfig.CreateGameDelay * 1e3);
+		ControlAction.createGame(gameInfo.gameName + gameCount, gameInfo.gamePass, 0);
+		locationTimeout(5000, location);
+
+		lastGameStatus = "pending";
+		
 		break;
 	case 5: // Join Game
 		D2Bot.updateStatus("Join Game");
@@ -554,7 +580,7 @@ MainSwitch:
 		}
 
 		ControlAction.timeoutDelay("Game Doesn't Exist", 1e4);
-		lastGameStatus = "ready";
+		ControlAction.click(6, 652, 469, 120, 20);
 
 		break;
 	case 38: // Game is full

--- a/d2bs/kolbot/D2BotGameAction.dbj
+++ b/d2bs/kolbot/D2BotGameAction.dbj
@@ -27,7 +27,8 @@ if (!FileTools.exists("data/" + me.profile + ".json")) {
 var handle, tag, gameInfo, gameStart, ingame, connectFail, charList,
 	ftj = 0,
 	lastGameStatus = "ready",
-	gameCount = DataFile.getStats().runs + 1;
+	gameCount = DataFile.getStats().runs + 1,
+	creatingActions = ["doMule"];
 
 function ReceiveCopyData(mode, msg) {
 	switch (msg) {
@@ -255,6 +256,12 @@ MainSwitch:
 
 		break;
 	case 4: // Create Game
+		if (creatingActions.indexOf(JSON.parse(tag).action) < 0) {
+			GameAction.update("done", "GameAction failed to create game!");
+			D2Bot.stop(me.profile,true);
+			break;
+		}
+	
 		D2Bot.updateStatus("Creating Game");
 
 		control = getControl(1, 657, 342, 27, 20);

--- a/d2bs/kolbot/D2BotGameAction.dbj
+++ b/d2bs/kolbot/D2BotGameAction.dbj
@@ -581,14 +581,12 @@ MainSwitch:
 
 		break;
 	case 26: // Lobby - Game Name Exists
-		ControlAction.timeoutDelay("Game Already Exists", 5e3);
-		
 		if (++ftj > 5) {
 			GameAction.update("done", "GameAction failed to create game!");
 			D2Bot.stop(me.profile,true);
 			break;
 		}
-		
+		ControlAction.timeoutDelay("Game Already Exists", 5e3);
 		ControlAction.click(6, 533, 469, 120, 20);
 
 		break;
@@ -596,15 +594,13 @@ MainSwitch:
 		ControlAction.click(6, 436, 538, 96, 32);
 
 		break;
-	case 28: // Lobby - Game Does Not Exist
-		ControlAction.timeoutDelay("Game Doesn't Exist", 5e3);
-		
+	case 28: // Lobby - Game Does Not Exist		
 		if (++ftj > 5) {
 			GameAction.update("done", "GameAction failed to join game!");
 			D2Bot.stop(me.profile,true);
 			break;
 		}
-		
+		ControlAction.timeoutDelay("Game Doesn't Exist", 5e3);
 		ControlAction.click(6, 652, 469, 120, 20);
 
 		break;

--- a/d2bs/kolbot/D2BotGameAction.dbj
+++ b/d2bs/kolbot/D2BotGameAction.dbj
@@ -190,6 +190,13 @@ MainSwitch:
 		}
 
 		if (GameAction.gameInfo() !== null) { // a game name was specified
+		
+			if (++ftj > 5) {
+				GameAction.update("done", "GameAction failed to join game!");
+				D2Bot.stop(me.profile,true);
+				break;
+			}
+			
 			if (!ControlAction.click(6, 533, 469, 120, 20)) { // Create screen to check if character is dead or not
 				break;
 			}
@@ -213,6 +220,13 @@ MainSwitch:
 				}
 			}
 		} else {
+			
+			if (++ftj > 5) {
+				GameAction.update("done", "GameAction failed to create game!");
+				D2Bot.stop(me.profile,true);
+				break;
+			}
+			
 			if (!ControlAction.click(6, 533, 469, 120, 20)) { // Create
 				break;
 			}
@@ -415,6 +429,9 @@ MainSwitch:
 
 		break;
 	case 12: // Character Select
+		// Reset ftj counter
+		ftj = 0;
+		
 		// Single Player screen fix
 		if (getLocation() === 12 && !getControl(4, 626, 100, 151, 44)) {
 			ControlAction.click(6, 33, 572, 128, 35);
@@ -564,6 +581,14 @@ MainSwitch:
 
 		break;
 	case 26: // Lobby - Game Name Exists
+		ControlAction.timeoutDelay("Game Already Exists", 5e3);
+		
+		if (++ftj > 5) {
+			GameAction.update("done", "GameAction failed to create game!");
+			D2Bot.stop(me.profile,true);
+			break;
+		}
+		
 		ControlAction.click(6, 533, 469, 120, 20);
 
 		break;
@@ -572,14 +597,14 @@ MainSwitch:
 
 		break;
 	case 28: // Lobby - Game Does Not Exist
-		ftj++;
-
-		if (ftj > 4) {
+		ControlAction.timeoutDelay("Game Doesn't Exist", 5e3);
+		
+		if (++ftj > 5) {
 			GameAction.update("done", "GameAction failed to join game!");
 			D2Bot.stop(me.profile,true);
+			break;
 		}
-
-		ControlAction.timeoutDelay("Game Doesn't Exist", 1e4);
+		
 		ControlAction.click(6, 652, 469, 120, 20);
 
 		break;


### PR DESCRIPTION
This will finally close #29:
- Still don't create games on failed join but
- Create games for mule logging again
- Reset ftj counter in character selection screen (otherwise multiple characters from same account in queue will share ftj)
- Avoid retry loop for unhandled UI locations (like uncorrect game difficulty when joining) by also incrementing ftj in lobby

I think especially the last point should be reviewed