### PR TITLE
fix Config.PublicMode = 1 (invite and accept)

### DIFF
--- a/d2bs/kolbot/tools/Party.js
+++ b/d2bs/kolbot/tools/Party.js
@@ -126,7 +126,9 @@ function main() {
 							delay(100);
 						}
 
-						break;
+						if (Config.PublicMode === 3) {
+							break;
+						}
 					case 2: // Accept invites
 						if (Config.Leader && player.name !== Config.Leader) {
 							break;


### PR DESCRIPTION
conditional break so that `Config.PublicMode = 1` runs the accept portion too, like it's supposed to.