### PR TITLE
Fix BreakClearLevel for MFHelper

### DIFF
--- a/d2bs/kolbot/libs/common/Attack.js
+++ b/d2bs/kolbot/libs/common/Attack.js
@@ -898,11 +898,12 @@ var Attack = {
 				room = getRoom(me.x, me.y);
 			}
 
-			if (Config.MFHelper && Config.MFHelper.BreakClearLevel && Config.Leader !== "") {
+			if (Loader.scriptName() === "MFHelper" && Config.MFHelper.BreakClearLevel && Config.Leader !== "") {
 				var leader = Misc.findPlayer(Config.Leader);
 
-				if (leader.area !== me.area && (!leader.inTown || Misc.getPlayerAct(Config.Leader) !== me.act)) {
+				if (leader && leader.area !== me.area && !leader.inTown) {
 					me.overhead("break the clearing in " + getArea().name);
+
 					return true;
 				}
 			}

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -437,7 +437,7 @@ var Config = {
 		RecheckSeals: false
 	},
 	MFHelper: {
-		BreakClearLevel: true
+		BreakClearLevel: false
 	},
 	Wakka: {
 		Wait: 1

--- a/d2bs/kolbot/libs/common/Misc.js
+++ b/d2bs/kolbot/libs/common/Misc.js
@@ -849,6 +849,10 @@ var Misc = {
 	getPlayerAct: function (player) {
 		var unit = this.findPlayer(player);
 
+		if (!unit) {
+			return false;
+		}
+
 		if (unit.area <= 39) {
 			return 1;
 		}

--- a/d2bs/kolbot/libs/config/_BaseConfigFile.js
+++ b/d2bs/kolbot/libs/config/_BaseConfigFile.js
@@ -22,6 +22,7 @@
 	// Team MF system
 	Config.MFLeader = false; // Set to true if you have one or more MFHelpers. Opens TP and gives commands when doing normal MF runs.
 	Scripts.MFHelper = false; // Run the same MF run as the MFLeader. Leader must have Config.MFLeader = true
+		Config.BreakClearLevel = false; // Stop clearing the current area if the leader goes to another area
 
 	// Leeching section
 	// leader's character name isn't needed on order to run. Don't use more scripts of the same type! (Run AutoBaal OR BaalHelper, not both)


### PR DESCRIPTION
This fixes an issue where "break the clearing" would get triggered even if the bot wasn't running MFHelper.