### PR TITLE
Rushee.js non-quester rushee fail to move to A3

### DIFF
--- a/d2bs/kolbot/libs/bots/Rushee.js
+++ b/d2bs/kolbot/libs/bots/Rushee.js
@@ -899,9 +899,14 @@ function Rushee() {
 					if (!this.changeAct(2)) {
 						break;
 					}
+					
+					Town.move(NPC.Atma);
+					target = getUnit(1, 176); // Atma
+					if (target && target.openMenu()) {
+						me.cancel();
+					}
 
 					target = getUnit(1, NPC.Jerhyn);
-
 					if (target) {
 						target.openMenu();
 					}
@@ -915,7 +920,7 @@ function Rushee() {
 					if (!this.changeAct(3)) {
 						break;
 					}
-
+					
 					Town.move("portalspot");
 					actions.shift();
 


### PR DESCRIPTION
The current non-quester rushee stucks when trying to move to a3.
It should move to Harem portal created by the Rusher and talk with Jerhyn, but the problem is the rusher cannot enter the portal since it has to talk with someone first.

So in this PR, I change the script when the non-quester rushee trying to move to a3, it talks to Atma first.
I've tested the script several times and it works fine.