### PR TITLE
Expose option to configure telekinesis in default Sorceress template

### DIFF
--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -547,6 +547,7 @@ function LoadConfig() {
 	// Class specific config
 	Config.CastStatic = 60; // Cast static until the target is at designated life percent. 100 = disabled.
 	Config.StaticList = []; // List of monster NAMES or CLASSIDS to static. Example: Config.StaticList = ["Andariel", 243];
+	Config.UseTelekinesis = false;
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -545,9 +545,9 @@ function LoadConfig() {
 	Config.Wereform = false; // 0 / false - don't shapeshift, 1 / "Werewolf" - change to werewolf, 2 / "Werebear" - change to werebear
 
 	// Class specific config
-	Config.CastStatic = 60; 	// Cast static until the target is at designated life percent. 100 = disabled.
-	Config.StaticList = [];		// List of monster NAMES or CLASSIDS to static. Example: Config.StaticList = ["Andariel", 243];
-	Config.UseTelekinesis = false;	// Use Telekinesis to pickup gold, potions, scrolls, etc.
+	Config.CastStatic = 60; // Cast static until the target is at designated life percent. 100 = disabled.
+	Config.StaticList = []; // List of monster NAMES or CLASSIDS to static. Example: Config.StaticList = ["Andariel", 243];
+	Config.UseTelekinesis = false; // Use Telekinesis to pick up gold, potions, scrolls, etc.
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.

--- a/d2bs/kolbot/libs/config/Sorceress.js
+++ b/d2bs/kolbot/libs/config/Sorceress.js
@@ -545,9 +545,9 @@ function LoadConfig() {
 	Config.Wereform = false; // 0 / false - don't shapeshift, 1 / "Werewolf" - change to werewolf, 2 / "Werebear" - change to werebear
 
 	// Class specific config
-	Config.CastStatic = 60; // Cast static until the target is at designated life percent. 100 = disabled.
-	Config.StaticList = []; // List of monster NAMES or CLASSIDS to static. Example: Config.StaticList = ["Andariel", 243];
-	Config.UseTelekinesis = false;
+	Config.CastStatic = 60; 	// Cast static until the target is at designated life percent. 100 = disabled.
+	Config.StaticList = [];		// List of monster NAMES or CLASSIDS to static. Example: Config.StaticList = ["Andariel", 243];
+	Config.UseTelekinesis = false;	// Use Telekinesis to pickup gold, potions, scrolls, etc.
 
 	/* AutoSkill builds character based on array defined by the user and it replaces AutoBuild's skill system.
 	 * AutoSkill will automatically spend skill points and it can also allocate any prerequisite skills as required.


### PR DESCRIPTION
This option appears in libs\common\Config.js under the Sorceress specific section, but was not added to the default Sorc template.