### PR TITLE
rework party thread to only party leader on mode 1

### DIFF
--- a/d2bs/kolbot/tools/Party.js
+++ b/d2bs/kolbot/tools/Party.js
@@ -121,7 +121,7 @@ function main() {
 							break;
 						}
 
-						if (player.partyflag !== 4 && (Config.PublicMode === 1 || player.partyflag !== 2) && player.partyid === 65535) {
+						if (player.partyflag !== 4 && player.partyflag !== 2 && player.partyflag !== 1 && player.partyid === 65535) {
 							clickParty(player, 2);
 							delay(100);
 						}
@@ -130,17 +130,19 @@ function main() {
 							break;
 						}
 					case 2: // Accept invites
-						if (Config.Leader && player.name !== Config.Leader) {
-							break;
-						}
+						if (myPartyId === 65535) {
+							if (Config.Leader && player.name !== Config.Leader) {
+								break;
+							}
 
-						if (player.partyid !== 65535 && player.partyid !== myPartyId) {
-							otherParty = player.partyid;
-						}
+							if (player.partyid !== 65535 && player.partyid !== myPartyId) {
+								otherParty = player.partyid;
+							}
 
-						if (player.partyflag === 2 && (!otherParty || player.partyid === otherParty) && (getTickCount() - partyTick >= 2000 || Config.FastParty)) {
-							clickParty(player, 2);
-							delay(100);
+							if (player.partyflag === 2 && (!otherParty || player.partyid === otherParty) && (getTickCount() - partyTick >= 2000 || Config.FastParty)) {
+								clickParty(player, 2);
+								delay(100);
+							}
 						}
 
 						break;


### PR DESCRIPTION
the previous method had the current player accepting invites from anyone. now on `Config.PublicMode = 1` the player only accepts invites from the leader if there is one, or if there isn't one then party with anyone (same as before).