### PR TITLE
Wereform.js: don't unshift when we don't need to

### DIFF
--- a/d2bs/kolbot/libs/common/Attacks/Wereform.js
+++ b/d2bs/kolbot/libs/common/Attacks/Wereform.js
@@ -111,7 +111,7 @@ var ClassAttack = {
 
 			// Teleport closer
 			if (Math.ceil(getDistance(me, unit)) > 10) {
-				if (!Config.NoTele) {
+				if (Pather.useTeleport()) {
 					Misc.unShift();
 				}
 
@@ -142,7 +142,7 @@ var ClassAttack = {
 
 			// Teleport closer
 			if (Math.ceil(getDistance(me, unit)) > 10) {
-				if (!Config.NoTele) {
+				if (Pather.useTeleport()) {
 					Misc.unShift();
 				}
 

--- a/d2bs/kolbot/libs/common/Attacks/Wereform.js
+++ b/d2bs/kolbot/libs/common/Attacks/Wereform.js
@@ -111,7 +111,9 @@ var ClassAttack = {
 
 			// Teleport closer
 			if (Math.ceil(getDistance(me, unit)) > 10) {
-				Misc.unShift();
+				if (!Config.NoTele) {
+					Misc.unShift();
+				}
 
 				if (!Attack.getIntoPosition(unit, 10, 0x4)) {
 					return 0;
@@ -140,7 +142,9 @@ var ClassAttack = {
 
 			// Teleport closer
 			if (Math.ceil(getDistance(me, unit)) > 10) {
-				Misc.unShift();
+				if (!Config.NoTele) {
+					Misc.unShift();
+				}
 
 				if (!Attack.getIntoPosition(unit, 10, 0x4)) {
 					return 0;


### PR DESCRIPTION
if teleport is disabled, there is no point in unshifting to move to another target