### PR TITLE
Added check for non quester to talk to Atma to enable harem portal.

### DIFF
--- a/d2bs/kolbot/libs/bots/Rushee.js
+++ b/d2bs/kolbot/libs/bots/Rushee.js
@@ -235,6 +235,18 @@ function Rushee() {
 					break;
 				}
 
+				if (!Config.Rushee.Quester) { // Non Quester needs to talk to Townsfolk to enable Harem TP
+					Town.move(NPC.Atma); // Talk to Atma
+
+					target = getUnit(1, 176); // Atma
+
+					if (target && target.openMenu()) {
+						me.cancel();
+					} else {
+						break;
+					}
+				}
+				
 				Pather.usePortal(50, Config.Leader);
 				Pather.moveToExit(40, true);
 
@@ -900,13 +912,6 @@ function Rushee() {
 						break;
 					}
 
-					target = getUnit(1, NPC.Jerhyn);
-
-					if (target) {
-						target.openMenu();
-					}
-
-					me.cancel();
 					Town.move("portalspot");
 					actions.shift();
 


### PR DESCRIPTION
* Added check for non quester to talk to Atma to enable harem portal.
* Removed talking to Jerhyn at the beginning of Act 2. Jerhyn moves to palace once rusher takes waypoint so rushee can't talk to him resulting in a time out.