### PR TITLE
_BaseConfigFile.js: modify perfect Spirit example

### DIFF
--- a/d2bs/kolbot/libs/config/_BaseConfigFile.js
+++ b/d2bs/kolbot/libs/config/_BaseConfigFile.js
@@ -532,7 +532,7 @@
 	Config.Runewords.push([Runeword.Spirit, "Kurast Shield"]); // Make Spirit Kurast Shield
 	//Config.Runewords.push([Runeword.Spirit, "Vortex Shield"]); // Make Spirit Vortex Shield
 	Config.KeepRunewords.push("[type] == sword || [type] == shield || [type] == auricshields # [fcr] == 35"); // middle spirit
-	//Config.KeepRunewords.push("[type] == sword || [type] == shield || [type] == auricshields # [fcr] == 35") && [maxmana] >= 112 && [itemabsorbmagic] >=8; // perfect spirit
+	//Config.KeepRunewords.push("[type] == sword || [type] == shield || [type] == auricshields # [fcr] == 35 && [maxmana] >= 112 && [itemabsorbmagic] >=8"); // perfect spirit
 
 	//Config.Runewords.push([Runeword.Prudence, "Sacred Armor", Roll.Eth]); // Make ethereal Prudence Sacred Armor
 	//Config.KeepRunewords.push("[type] == Armor # [enhanceddefense] == 170 && [fireresist] == 35");


### PR DESCRIPTION
The other "alternate" runeword examples are provided with a line you can just toggle on/off, this is the only one where you have to modify the nip syntax. Correcting that.