### PR TITLE
Baal/Diablo Helper's TPs After Kill

### DIFF
--- a/d2bs/kolbot/libs/bots/BaalHelper.js
+++ b/d2bs/kolbot/libs/bots/BaalHelper.js
@@ -342,8 +342,8 @@ MainLoop:
 		Pather.moveTo(15134, 5923);
 		Attack.kill(544); // Baal
 		Pickit.pickItems();
-		if (!Pather.getPortal(null, Config.Leader) || !Pather.usePortal(null, Config.Leader)) {
-			Town.goToTown();
+		if (Pather.getPortal(null, Config.Leader)) {
+			Pather.usePortal(null, Config.Leader);
 		}
 	} else {
 		while (true) {

--- a/d2bs/kolbot/libs/bots/BaalHelper.js
+++ b/d2bs/kolbot/libs/bots/BaalHelper.js
@@ -342,6 +342,9 @@ MainLoop:
 		Pather.moveTo(15134, 5923);
 		Attack.kill(544); // Baal
 		Pickit.pickItems();
+		if (!Pather.getPortal(null, Config.Leader) || !Pather.usePortal(null, Config.Leader)) {
+			Town.goToTown();
+		}
 	} else {
 		while (true) {
 			delay(500);

--- a/d2bs/kolbot/libs/bots/DiabloHelper.js
+++ b/d2bs/kolbot/libs/bots/DiabloHelper.js
@@ -564,8 +564,8 @@ CSLoop:
 	Attack.kill(243); // Diablo
 	Pickit.pickItems();
 
-	if (!Pather.getPortal(null, Config.Leader) || !Pather.usePortal(null, Config.Leader)) {
-		Town.goToTown();
+	if (Pather.getPortal(null, Config.Leader)) {
+		Pather.usePortal(null, Config.Leader);
 	}
 
 	return true;

--- a/d2bs/kolbot/libs/bots/DiabloHelper.js
+++ b/d2bs/kolbot/libs/bots/DiabloHelper.js
@@ -564,5 +564,9 @@ CSLoop:
 	Attack.kill(243); // Diablo
 	Pickit.pickItems();
 
+	if (!Pather.getPortal(null, Config.Leader) || !Pather.usePortal(null, Config.Leader)) {
+		Town.goToTown();
+	}
+
 	return true;
 }


### PR DESCRIPTION
Use the same logic as MFHelper to try and take Config.Leader's TP back to town before making our own.

This prevents each and every helper from making a TP after the boss is dead.