### PR TITLE
Increasing General Performance of MFHelper and al

### DIFF
--- a/d2bs/kolbot/libs/bots/MFHelper.js
+++ b/d2bs/kolbot/libs/bots/MFHelper.js
@@ -164,7 +164,7 @@ MainLoop:
 					break MainLoop;
 				} else if (command.indexOf("goto") > -1) {
 					print("ÿc4MFHelperÿc0: Goto");
-					split = command.split("goto A")[1];
+					split = command.substr(6);
 
 					try {
 						if (!!parseInt(split, 10)) {

--- a/d2bs/kolbot/libs/bots/MFHelper.js
+++ b/d2bs/kolbot/libs/bots/MFHelper.js
@@ -120,8 +120,8 @@ function MFHelper() {
 	
 	
 	if (player) {
-		while (!player.area) {
-			delay(100 + me.ping);
+		if (!Misc.poll(() => player.area, 120*60, 100 + me.ping)) {
+			throw new Error('Failed to wait for player area');
 		}
 
 		playerAct = Misc.getPlayerAct(Config.Leader);

--- a/d2bs/kolbot/libs/bots/MFHelper.js
+++ b/d2bs/kolbot/libs/bots/MFHelper.js
@@ -129,6 +129,7 @@ function MFHelper() {
 		if (playerAct && playerAct !== me.act) {
 			Town.goToTown(playerAct);
 			Town.move("portalspot");
+		}
 	}
 
 	// START

--- a/d2bs/kolbot/libs/bots/MFHelper.js
+++ b/d2bs/kolbot/libs/bots/MFHelper.js
@@ -12,7 +12,7 @@ function MFHelper() {
 	function ChatEvent(name, msg) {
 		if (!player) {
 			var i,
-				match = ["kill", "clearlevel", "clear", "quit", "cows", "council"];
+				match = ["kill", "clearlevel", "clear", "quit", "cows", "council", "goto"];
 
 			if (msg) {
 				for (i = 0; i < match.length; i += 1) {
@@ -117,6 +117,19 @@ function MFHelper() {
 
 		player = Misc.findPlayer(Config.Leader);
 	}
+	
+	
+	if (player) {
+		while (!player.area) {
+			delay(100 + me.ping);
+		}
+
+		playerAct = Misc.getPlayerAct(Config.Leader);
+
+		if (playerAct && playerAct !== me.act) {
+			Town.goToTown(playerAct);
+			Town.move("portalspot");
+	}
 
 	// START
 MainLoop:
@@ -132,16 +145,6 @@ MainLoop:
 		}
 
 		if (player) {
-			while (!player.area) {
-				delay(100 + me.ping);
-			}
-
-			playerAct = Misc.getPlayerAct(Config.Leader);
-
-			if (playerAct && playerAct !== me.act) {
-				Town.goToTown(playerAct);
-				Town.move("portalspot");
-			}
 
 			if (Config.LifeChicken > 0 && me.hp <= Math.floor(me.hpmax * Config.LifeChicken / 100)) {
 				Town.heal();
@@ -155,9 +158,25 @@ MainLoop:
 
 			if (command !== oldCommand) {
 				oldCommand = command;
-
+				
 				if (command.indexOf("quit") > -1) {
 					break MainLoop;
+				} else if (command.indexOf("goto") > -1) {
+					print("ÿc4MFHelperÿc0: Goto");
+					split = command.split("goto A")[1];
+
+					try {
+						if (!!parseInt(split, 10)) {
+								split = parseInt(split, 10);
+							}
+						
+						Town.goToTown(split, true);
+						Town.move("portalspot");
+					} catch (townerror) {
+						print(townerror);
+					}
+					
+					delay(500 + me.ping);
 				} else if (command.indexOf("cows") > -1) {
 					print("ÿc4MFHelperÿc0: Clear Cows");
 

--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -868,28 +868,15 @@ ModeLoop:
 	targetArea - id of the area to enter
 	*/
 	getAct: function getAct(targetArea) {
-		var actNumber,
-			lo,
-			hi,
-			areas = [39, 74, 102, 108, 132];
-		
-
-		hi = areas.length;
-		lo = 0;
-		
-		while (hi >= lo) {
-			actNumber = ((hi - lo) / 2|0) + lo;
-			
-			if (targetArea <= areas[actNumber]) {
-				hi = actNumber - 1;
-			} else {
-				lo = actNumber + 1;
+		const areas = [0, 40, 75, 103, 109];
+	
+		while (areas.length) {
+			if (areas.pop() < targetArea) {
+				return areas.length + 1;
 			}
-			
 		}
 		
-
-		return lo + 1;
+		return 0;
 	},
 	
 	

--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -861,6 +861,51 @@ ModeLoop:
 
 		return targetArea ? me.area === targetArea : me.area !== preArea;
 	},
+	
+	
+	/*
+	Pather.getAct(targetArea);
+	targetArea - id of the area to enter
+	*/
+	getAct: function getAct(targetArea) {
+		var actNumber,
+			lo,
+			hi,
+			areas = [39, 74, 102, 108, 132];
+		
+
+		hi = areas.length;
+		lo = 0;
+		
+		while (hi >= lo) {
+			actNumber = ((hi - lo) / 2|0) + lo;
+			
+			if (targetArea <= areas[actNumber]) {
+				hi = actNumber - 1;
+			} else {
+				lo = actNumber + 1;
+			}
+			
+		}
+		
+
+		return lo + 1;
+	},
+	
+	
+	/*
+	Pather.broadcastIntent(targetArea);
+	targetArea - id of the area to enter
+	*/
+	broadcastIntent: function broadcastIntent(targetArea) {
+		var myAct = me.act,
+			targetAct = this.getAct(targetArea);
+		
+		if (Config.MFLeader && myAct !== targetAct) {
+			say("goto A" + targetAct);
+		}
+	
+	},
 
 	/*
 		Pather.moveTo(targetArea, check);
@@ -887,7 +932,8 @@ ModeLoop:
 
 			break;
 		}
-
+		this.broadcastIntent(targetArea);
+		
 		var i, tick, wp, coord, retry, npc;
 
 		for (i = 0; i < 12; i += 1) {

--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -898,13 +898,14 @@ ModeLoop:
 	targetArea - id of the area to enter
 	*/
 	broadcastIntent: function broadcastIntent(targetArea) {
-		var myAct = me.act,
-			targetAct = this.getAct(targetArea);
-		
-		if (Config.MFLeader && myAct !== targetAct) {
-			say("goto A" + targetAct);
+		if (Config.MFLeader) {
+			var targetAct = this.getAct(targetArea);
+
+			if (me.act !== targetAct) {
+				say("goto A" + targetAct);
+			}
 		}
-	
+		
 	},
 
 	/*

--- a/d2bs/kolbot/libs/common/Pickit.js
+++ b/d2bs/kolbot/libs/common/Pickit.js
@@ -265,7 +265,7 @@ MainLoop:
 
 			if (stats.useTk) {
 				Skill.setSkill(43, 0);
-				Packet.castSkill(0, item.x, item.y);
+				Packet.unitCast(0, item);
 			} else {
 				if (getDistance(me, item) > (Config.FastPick === 2 && i < 1 ? 6 : 4) || checkCollision(me, item, 0x1)) {
 					if (Pather.useTeleport()) {

--- a/d2bs/kolbot/libs/common/Pickit.js
+++ b/d2bs/kolbot/libs/common/Pickit.js
@@ -264,7 +264,8 @@ MainLoop:
 			}
 
 			if (stats.useTk) {
-				Skill.cast(43, 0, item);
+				Skill.setSkill(43, 0);
+				Packet.castSkill(0, item.x, item.y);
 			} else {
 				if (getDistance(me, item) > (Config.FastPick === 2 && i < 1 ? 6 : 4) || checkCollision(me, item, 0x1)) {
 					if (Pather.useTeleport()) {

--- a/d2bs/kolbot/libs/common/Pickit.js
+++ b/d2bs/kolbot/libs/common/Pickit.js
@@ -264,8 +264,12 @@ MainLoop:
 			}
 
 			if (stats.useTk) {
-				Skill.setSkill(43, 0);
-				Packet.unitCast(0, item);
+				if (Config.PacketCasting == 2) {
+					Skill.setSkill(43, 0);
+					Packet.unitCast(0, item);
+				} else {
+					Skill.cast(43, 0, item);
+				}
 			} else {
 				if (getDistance(me, item) > (Config.FastPick === 2 && i < 1 ? 6 : 4) || checkCollision(me, item, 0x1)) {
 					if (Pather.useTeleport()) {


### PR DESCRIPTION
Previous implementation relied on the leader's current act and resulted in huge delays between changing towns. This motivated me to remove the redundant checks for the leader's act to only once - when the player first joins the game. The remaining act changes are performed by the leader telling the helper to switch acts (much like in follower).

The code has been tested on a stable release and I saw some differences between the stable and dev version. I'd appreciate it if you can confirm it works.