### PR TITLE
Make Storage to Work Better with Belts

### DIFF
--- a/d2bs/kolbot/libs/common/Cubing.js
+++ b/d2bs/kolbot/libs/common/Cubing.js
@@ -1185,7 +1185,7 @@ IngredientLoop:
 					me.cancel(); // inventory
 
 					// If the storage location is known, put the pot to this location
-					Storage[orgin.location] && Storage[orgin.location].moveTo(fullrev);
+					Storage[orgin.location] && Storage[orgin.location].MoveTo(fullrev);
 
 					// If returned true, the prototype some stops looping.
 					return fullrev.location !== locations.Cube;

--- a/d2bs/kolbot/libs/common/Storage.js
+++ b/d2bs/kolbot/libs/common/Storage.js
@@ -31,7 +31,7 @@ var Container = function (name, width, height, location) {
 		var x, y;
 
 		//Make sure it is in this container.
-		if (item.location !== this.location || item.mode !== 0) {
+		if (item.location !== this.location || (item.mode !== 0 && item.mode !== 2)) {
 			return false;
 		}
 
@@ -98,6 +98,7 @@ var Container = function (name, width, height, location) {
 		}
 
 		this.itemList = [];
+		this.openPositions = this.height * this.width;
 		return true;
 	};
 
@@ -193,6 +194,11 @@ Loop:
 
 					if (cItem !== null && cube !== null) {
 						sendPacket(1, 0x2a, 4, cItem.gid, 4, cube.gid);
+					}
+				} else if (this.location === 2) {
+					cItem = getUnit(100);
+					if (cItem !== null) {
+						sendPacket(1, 0x23, 4, cItem.gid, 4, nPos.y);
 					}
 				} else {
 					clickItemAndWait(0, nPos.y, nPos.x, this.location);


### PR DESCRIPTION
Noticed that the makeRevPots function wasn't working as expected, namely it would always put the full rejuv in the first row/column when taking regulars from the belt after the typo was fixed despite there already being a pot there. As generally that is used for hp the char would drink it.

Placing them in the wrong column was due to the belt not properly being marked, also found that if the first row is already full that clickItemAndWait() wouldn't actually place the pot in any of the higher rows.

makeRevPots() should always be called after doing a Town.buyPotions() as it will try to put full rejuvs in the first open belt location (if that's where the plain rejuv came from) so best to make sure only rv columns are available.