### PR TITLE
1) Custom curses; 2) Cow parallel runs; 3) Precast based on item skills; 4) Pather works on red portals

### DIFF
--- a/d2bs/kolbot/libs/bots/Cows.js
+++ b/d2bs/kolbot/libs/bots/Cows.js
@@ -224,9 +224,25 @@ function Cows() {
 			throw new Error("Already killed the Cow King.");
 		}
 		
-		leg = this.getLeg();
-		tome = this.getTome();
-		this.openPortal(leg, tome);
+		try {
+			leg = this.getLeg();
+			tome = this.getTome();
+			this.openPortal(leg, tome);
+		}
+		catch(err) {
+			
+			// Maybe someone else was trying to create a portal at the same time? Wait up to 15s.
+			Town.goToTown();
+			delay(500);
+			for (var i = 0; i < 15; i += 1) {
+				if (!Pather.getPortal(39)) {
+					delay(1000);
+				}
+			}
+			if (!Pather.getPortal(39)) {
+				throw new Error("Can't get leg. Waited 15s and no one created portal.")
+			}
+		}
 	}
 
 	Pather.usePortal(39);

--- a/d2bs/kolbot/libs/common/Attacks/Necromancer.js
+++ b/d2bs/kolbot/libs/common/Attacks/Necromancer.js
@@ -10,6 +10,9 @@ var ClassAttack = {
 	CurseDict: {},
 
 	initCurses: function () {
+		// Maps curse id to curse state in monster.
+		// Nothing; Amplify Damage; Dim Vision; Weaken; Iron Maiden; 
+		// Terror; Confuse; Life Tap; Attract; Decrepify; Lower Resist
 		this.CurseDict = {0:0, 66:9, 71:23, 72:19, 76:55, 77:56, 81:59, 82:58, 86:57, 87:60, 91:61};
 		this.cursesSet = true;
 	},

--- a/d2bs/kolbot/libs/common/Attacks/Necromancer.js
+++ b/d2bs/kolbot/libs/common/Attacks/Necromancer.js
@@ -7,65 +7,10 @@
 var ClassAttack = {
 	novaTick: 0,
 	cursesSet: false,
-	curseState: [],
+	CurseDict: {},
 
 	initCurses: function () {
-		var i;
-
-		for (i = 0; i < Config.Curse.length; i += 1) {
-			switch (Config.Curse[i]) {
-			case 0: //nothing
-				this.curseState[i] = 0;
-
-				break;
-			case 66: //amplify damage
-				this.curseState[i] = 9;
-
-				break;
-			case 71: //dim vision
-				this.curseState[i] = 23;
-
-				break;
-			case 72: //weaken
-				this.curseState[i] = 19;
-
-				break;
-			case 76: //iron maiden
-				this.curseState[i] = 55;
-
-				break;
-			case 77: //terror
-				this.curseState[i] = 56;
-
-				break;
-			case 81: //confuse
-				this.curseState[i] = 59;
-
-				break;
-			case 82: //life tap
-				this.curseState[i] = 58;
-
-				break;
-			case 86: //attract
-				this.curseState[i] = 57;
-
-				break;
-			case 87: //decrepify
-				this.curseState[i] = 60;
-
-				break;
-			case 91: //lower resist
-				this.curseState[i] = 61;
-
-				break;
-			default:
-				Config.Curse[i] = 0;
-				print("Invalid curse id");
-
-				break;
-			}
-		}
-
+		this.CurseDict = {0:0, 66:9, 71:23, 72:19, 76:55, 77:56, 81:59, 82:58, 86:57, 87:60, 91:61};
 		this.cursesSet = true;
 	},
 
@@ -97,28 +42,43 @@ var ClassAttack = {
 
 		index = ((unit.spectype & 0x7) || unit.type === 0) ? 1 : 3;
 
-		if (Config.Curse[0] > 0 && this.isCursable(unit) && (unit.spectype & 0x7) && !unit.getState(this.curseState[0])) {
-			if (getDistance(me, unit) > 25 || checkCollision(me, unit, 0x4)) {
-				if (!Attack.getIntoPosition(unit, 25, 0x4)) {
-					return 0;
+		if (unit.name in Config.CustomCurse) {
+						
+			if (((Config.Curse[0] > 0 && this.isCursable(unit))) && !unit.getState(this.CurseDict[Config.CustomCurse[unit.name]])) {
+				if (getDistance(me, unit) > 25 || checkCollision(me, unit, 0x4)) {
+					if (!Attack.getIntoPosition(unit, 25, 0x4)) {
+						return 0;
+					}
 				}
+				Skill.cast(Config.CustomCurse[unit.name], 0, unit);
+
+				return 1;
 			}
-
-			Skill.cast(Config.Curse[0], 0, unit);
-
-			return 1;
 		}
-
-		if (Config.Curse[1] > 0 && this.isCursable(unit) && !(unit.spectype & 0x7) && !unit.getState(this.curseState[1])) {
-			if (getDistance(me, unit) > 25 || checkCollision(me, unit, 0x4)) {
-				if (!Attack.getIntoPosition(unit, 25, 0x4)) {
-					return 0;
+		else {
+			if ((Config.Curse[0] > 0 && this.isCursable(unit) && (unit.spectype & 0x7)) && !unit.getState(this.CurseDict[Config.Curse[0]])) {
+				if (getDistance(me, unit) > 25 || checkCollision(me, unit, 0x4)) {
+					if (!Attack.getIntoPosition(unit, 25, 0x4)) {
+						return 0;
+					}
 				}
+
+				Skill.cast(Config.Curse[0], 0, unit);
+
+				return 1;
 			}
 
-			Skill.cast(Config.Curse[1], 0, unit);
+			if (((Config.Curse[1] > 0 && this.isCursable(unit) && !(unit.spectype & 0x7))) && !unit.getState(this.CurseDict[Config.Curse[1]])) {
+				if (getDistance(me, unit) > 25 || checkCollision(me, unit, 0x4)) {
+					if (!Attack.getIntoPosition(unit, 25, 0x4)) {
+						return 0;
+					}
+				}
 
-			return 1;
+				Skill.cast(Config.Curse[1], 0, unit);
+
+				return 1;
+			}
 		}
 
 		// Get timed skill

--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -1403,124 +1403,142 @@ MainLoop:
 	*/
 	journeyTo: function (area) {
 		var i, special, unit, tick, target;
+		print("traveling to " + area);
+		switch (area) {
+		case 133:
+		case 134:
+		case 135:
+		case 136:
+			Town.goToTown(5)
+			print("Heading to act 5");
+			Pather.usePortal(area)
+			print("Using Portal " + area);
+			break;
+		case 39:
+			Town.goToTown(1)
+			print("Heading to act 1");
+			Pather.usePortal(39)
+			print("Using Portal " + area);
+			break;
 
-		target = this.plotCourse(area, me.area);
+		default:
+			target = this.plotCourse(area, me.area);
+			print(target.course);
 
-		print(target.course);
+			if (target.useWP) {
+				Town.goToTown();
+			}
 
-		if (target.useWP) {
-			Town.goToTown();
-		}
+			// handle variable flayer jungle entrances
+			if (target.course.indexOf(78) > -1) {
+				Town.goToTown(3); // without initiated act, getArea().exits will crash
 
-		// handle variable flayer jungle entrances
-		if (target.course.indexOf(78) > -1) {
-			Town.goToTown(3); // without initiated act, getArea().exits will crash
+				special = getArea(78);
 
-			special = getArea(78);
+				if (special) {
+					special = special.exits;
 
-			if (special) {
-				special = special.exits;
+					for (i = 0; i < special.length; i += 1) {
+						if (special[i].target === 77) {
+							target.course.splice(target.course.indexOf(78), 0, 77); // add great marsh if needed
 
-				for (i = 0; i < special.length; i += 1) {
-					if (special[i].target === 77) {
-						target.course.splice(target.course.indexOf(78), 0, 77); // add great marsh if needed
-
-						break;
+							break;
+						}
 					}
 				}
 			}
-		}
 
-		while (target.course.length) {
-			if (!me.inTown) {
-				Precast.doPrecast(false);
-			}
+			while (target.course.length) {
+				if (!me.inTown) {
+					Precast.doPrecast(false);
+				}
 
-			if (this.wpAreas.indexOf(me.area) > -1 && !getWaypoint(this.wpAreas.indexOf(me.area))) {
-				this.getWP(me.area);
-			}
+				if (this.wpAreas.indexOf(me.area) > -1 && !getWaypoint(this.wpAreas.indexOf(me.area))) {
+					this.getWP(me.area);
+				}
 
-			if (me.inTown && this.wpAreas.indexOf(target.course[0]) > -1 && getWaypoint(this.wpAreas.indexOf(target.course[0]))) {
-				this.useWaypoint(target.course[0], !this.plotCourse_openedWpMenu);
-				Precast.doPrecast(false);
-			} else if (me.area === 109 && target.course[0] === 110) { // Harrogath -> Bloody Foothills
-				this.moveTo(5026, 5095);
+				if (me.inTown && this.wpAreas.indexOf(target.course[0]) > -1 && getWaypoint(this.wpAreas.indexOf(target.course[0]))) {
+					this.useWaypoint(target.course[0], !this.plotCourse_openedWpMenu);
+					Precast.doPrecast(false);
+				} else if (me.area === 109 && target.course[0] === 110) { // Harrogath -> Bloody Foothills
+					this.moveTo(5026, 5095);
 
-				unit = getUnit(2, 449); // Gate
+					unit = getUnit(2, 449); // Gate
 
-				if (unit) {
-					for (i = 0; i < 3; i += 1) {
-						if (unit.mode) {
-							break;
-						}
-
-						Misc.click(0, 0, unit);
-						//unit.interact();
-
-						tick = getTickCount();
-
-						while (getTickCount() - tick < 3000) {
+					if (unit) {
+						for (i = 0; i < 3; i += 1) {
 							if (unit.mode) {
-								delay(1000);
-
 								break;
 							}
 
-							delay(10);
+							Misc.click(0, 0, unit);
+							//unit.interact();
+
+							tick = getTickCount();
+
+							while (getTickCount() - tick < 3000) {
+								if (unit.mode) {
+									delay(1000);
+
+									break;
+								}
+
+								delay(10);
+							}
 						}
 					}
-				}
 
-				this.moveToExit(target.course[0], true);
-			} else if (me.area === 4 && target.course[0] === 38) { // Stony Field -> Tristram
-				this.moveToPreset(me.area, 1, 737, 0, 0, false, true);
+					this.moveToExit(target.course[0], true);
+				} else if (me.area === 4 && target.course[0] === 38) { // Stony Field -> Tristram
+					this.moveToPreset(me.area, 1, 737, 0, 0, false, true);
 
-				for (i = 0; i < 5; i += 1) {
-					if (this.usePortal(38)) {
-						break;
+					for (i = 0; i < 5; i += 1) {
+						if (this.usePortal(38)) {
+							break;
+						}
+
+						delay(1000);
 					}
+				} else if (me.area === 40 && target.course[0] === 47) { // Lut Gholein -> Sewers Level 1 (use Trapdoor)
+					this.moveToPreset(me.area, 5, 19);
+					this.useUnit(2, 74, 47);
+				} else if (me.area === 74 && target.course[0] === 46) { // Arcane Sanctuary -> Canyon of the Magi
+					this.moveToPreset(me.area, 2, 357);
 
-					delay(1000);
-				}
-			} else if (me.area === 40 && target.course[0] === 47) { // Lut Gholein -> Sewers Level 1 (use Trapdoor)
-				this.moveToPreset(me.area, 5, 19);
-				this.useUnit(2, 74, 47);
-			} else if (me.area === 74 && target.course[0] === 46) { // Arcane Sanctuary -> Canyon of the Magi
-				this.moveToPreset(me.area, 2, 357);
+					for (i = 0; i < 5; i += 1) {
+						unit = getUnit(2, 357);
 
-				for (i = 0; i < 5; i += 1) {
-					unit = getUnit(2, 357);
+						Misc.click(0, 0, unit);
+						delay(1000);
+						me.cancel();
 
-					Misc.click(0, 0, unit);
-					delay(1000);
-					me.cancel();
-
-					if (this.usePortal(46)) {
-						break;
+						if (this.usePortal(46)) {
+							break;
+						}
 					}
+				} else if (me.area === 54 && target.course[0] === 74) { // Palace -> Arcane
+					this.moveTo(10073, 8670);
+					this.usePortal(null);
+				} else if (me.area === 109 && target.course[0] === 121) { // Harrogath -> Nihlathak's Temple
+					Town.move(NPC.Anya);
+					this.usePortal(121);
+				} else if (me.area === 111 && target.course[0] === 125) { // Abaddon
+					this.moveToPreset(111, 2, 60);
+					this.usePortal(125);
+				} else if (me.area === 112 && target.course[0] === 126) { // Pits of Archeon
+					this.moveToPreset(112, 2, 60);
+					this.usePortal(126);
+				} else if (me.area === 117 && target.course[0] === 127) { // Infernal Pit
+					this.moveToPreset(117, 2, 60);
+					this.usePortal(127);
+				} else {
+					this.moveToExit(target.course[0], true);
 				}
-			} else if (me.area === 54 && target.course[0] === 74) { // Palace -> Arcane
-				this.moveTo(10073, 8670);
-				this.usePortal(null);
-			} else if (me.area === 109 && target.course[0] === 121) { // Harrogath -> Nihlathak's Temple
-				Town.move(NPC.Anya);
-				this.usePortal(121);
-			} else if (me.area === 111 && target.course[0] === 125) { // Abaddon
-				this.moveToPreset(111, 2, 60);
-				this.usePortal(125);
-			} else if (me.area === 112 && target.course[0] === 126) { // Pits of Archeon
-				this.moveToPreset(112, 2, 60);
-				this.usePortal(126);
-			} else if (me.area === 117 && target.course[0] === 127) { // Infernal Pit
-				this.moveToPreset(117, 2, 60);
-				this.usePortal(127);
-			} else {
-				this.moveToExit(target.course[0], true);
+
+				target.course.shift();
 			}
 
-			target.course.shift();
 		}
-
 		return me.area === area;
 	},
 

--- a/d2bs/kolbot/libs/common/Precast.js
+++ b/d2bs/kolbot/libs/common/Precast.js
@@ -144,35 +144,35 @@ var Precast = new function () {
 
 			break;
 		case 1: // Sorceress
-			if (me.getSkill(57, 0) && (!me.getState(38) || force)) {
+			if (me.getSkill(57, 1) && (!me.getState(38) || force)) {
 				this.precastSkill(57); // Thunder Storm
 			}
 
-			if (me.getSkill(58, 0) && (!me.getState(30) || force)) {
+			if (me.getSkill(58, 1) && (!me.getState(30) || force)) {
 				this.precastSkill(58); // Energy Shield
 			}
 
-			if (me.getSkill(50, 0)) {
+			if (me.getSkill(50, 1)) {
 				if (!me.getState(88) || force) {
 					this.precastSkill(50); // Shiver Armor
 				}
-			} else if (me.getSkill(60, 0)) {
+			} else if (me.getSkill(60, 1)) {
 				if (!me.getState(20) || force) {
 					this.precastSkill(60); // Chilling Armor
 				}
-			} else if (me.getSkill(40, 0)) {
+			} else if (me.getSkill(40, 1)) {
 				if (!me.getState(10) || force) {
 					this.precastSkill(40); // Frozen Armor
 				}
 			}
 
-			if (me.getSkill(52, 0) && (!me.getState(16) || force)) {
+			if (me.getSkill(52, 1) && (!me.getState(16) || force)) {
 				this.enchant();
 			}
 
 			break;
 		case 2: // Necromancer
-			if (me.getSkill(68, 0) && (!me.getState(14) || force)) {
+			if (me.getSkill(68, 1) && (!me.getState(14) || force)) {
 				this.precastSkill(68); // Bone Armor
 			}
 
@@ -196,7 +196,7 @@ var Precast = new function () {
 
 			break;
 		case 3: // Paladin
-			if (me.getSkill(117, 0) && (!me.getState(101) || force)) {
+			if (me.getSkill(117, 1) && (!me.getState(101) || force)) {
 				this.precastSkill(117); // Holy Shield
 			}
 
@@ -224,7 +224,7 @@ var Precast = new function () {
 
 			break;
 		case 5: // Druid
-			if (me.getSkill(235, 0) && (!me.getState(151) || force)) {
+			if (me.getSkill(235, 1) && (!me.getState(151) || force)) {
 				this.precastSkill(235); // Cyclone Armor
 			}
 
@@ -286,7 +286,7 @@ var Precast = new function () {
 				break;
 			}
 
-			if (me.getSkill(250, 0) && (!me.getState(144) || force)) {
+			if (me.getSkill(250, 1) && (!me.getState(144) || force)) {
 				Skill.cast(250, 0); // Hurricane
 			}
 
@@ -308,19 +308,19 @@ var Precast = new function () {
 
 			break;
 		case 6: // Assassin
-			if (me.getSkill(267, 0) && Config.UseFade && (!me.getState(159) || force)) {
+			if (me.getSkill(267, 1) && Config.UseFade && (!me.getState(159) || force)) {
 				this.precastSkill(267); // Fade
 			}
 
-			if (me.getSkill(278, 0) && Config.UseVenom && (!me.getState(31) || force)) {
+			if (me.getSkill(278, 1) && Config.UseVenom && (!me.getState(31) || force)) {
 				Skill.cast(278, 0); // Venom
 			}
 
-			if (me.getSkill(277, 0) && (!me.getState(158) || force)) {
+			if (me.getSkill(277, 1) && (!me.getState(158) || force)) {
 				this.precastSkill(277); // Blade Shield
 			}
 
-			if (me.getSkill(258, 0) && !Config.UseFade && Config.UseBoS && (!me.getState(157) || force)) {
+			if (me.getSkill(258, 1) && !Config.UseFade && Config.UseBoS && (!me.getState(157) || force)) {
 				this.precastSkill(258); // Burst of Speed
 			}
 

--- a/d2bs/kolbot/libs/config/Necromancer.js
+++ b/d2bs/kolbot/libs/config/Necromancer.js
@@ -546,6 +546,7 @@ function LoadConfig() {
 	// Class specific config
 	Config.Curse[0] = 0; // Boss curse. Use skill number or set to 0 to disable.
 	Config.Curse[1] = 0; // Other monsters curse. Use skill number or set to 0 to disable.
+	Config.CustomCurse = {} // Allows custom curses for specific monsters. eg: {"Oblivion Knight": 87, "Minion of Destruction": 87}
 
 	Config.ExplodeCorpses = 0; // Explode corpses. Use skill number or 0 to disable. 74 = Corpse Explosion, 83 = Poison Explosion
 	Config.Golem = "None"; // Golem. 0 or "None" = don't summon, 1 or "Clay" = Clay Golem, 2 or "Blood" = Blood Golem, 3 or "Fire" = Fire Golem


### PR DESCRIPTION
This should allow more efficient killing of certain monster types.

Usage Example 1:

`
Config.Curse[0] = 66; // Boss curse. Use skill number or set to 0 to disable.  (66: AmpDmg)
Config.Curse[1] = 71; // Other monsters curse. Use skill number or set to 0 to disable. (87: Decrepify)
Config.CustomCurse = {"Oblivion Knight": 87, "Minion of Destruction": 87, "Unraveller": 66}
`

I cast dim vision on most monsters for survability but Oblivion Knight / Min of Destruction are immune to this curse. This would allow me to cast Decrepify on them instead. I'm a bone necro so for magic immunes (eg. Unraveller) I want to cast amp dmg on them so merc can kill them faster.

Usage Example 2:
I run some parts of the game solo before meeting up with sorc at Baal. So I only want to use lower resist for Baal's minions - can do something like this:
`{"Minion of Destruction": 87}`