### PR TITLE
Added override from private project for theGuy

### DIFF
--- a/d2bs/kolbot/libs/modules/Override.js
+++ b/d2bs/kolbot/libs/modules/Override.js
@@ -1,0 +1,59 @@
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.Override = void 0;
+    var Override = /** @class */ (function () {
+        function Override(target, original, method) {
+            this.target = target;
+            if (typeof original !== 'string') {
+                this.original = original;
+                this.key = Object.keys(target).find(function (key) { return target[key] === original; });
+            }
+            else {
+                this.original = undefined;
+                this.key = original;
+            }
+            this.method = method;
+            Override.all.push(this);
+        }
+        Override.prototype.apply = function () {
+            var _a = this, target = _a.target, key = _a.key, method = _a.method, original = _a.original;
+            target[key] = function () {
+                var args = [];
+                for (var _i = 0; _i < arguments.length; _i++) {
+                    args[_i] = arguments[_i];
+                }
+                return method.apply(this, __spreadArray([original && original.bind(this)], args, true));
+            };
+        };
+        Override.prototype.rollback = function () {
+            var _a = this, target = _a.target, key = _a.key, original = _a.original;
+            if (original) {
+                target[key] = original;
+            }
+            else {
+                delete target[key];
+            }
+        };
+        Override.all = [];
+        return Override;
+    }());
+    exports.Override = Override;
+});

--- a/d2bs/kolbot/libs/modules/Override.ts
+++ b/d2bs/kolbot/libs/modules/Override.ts
@@ -1,0 +1,39 @@
+export class Override<T extends object, M extends ((...args: any) => any)> {
+
+    public readonly target: T;
+    public readonly key: string|number|symbol;
+    public readonly original?: M;
+    public readonly method;
+
+    static readonly all: Override<object, (...args: any) => any>[] = [];
+
+    constructor(target: T, original: M|keyof T, method: (this: T, original: M, ...args: any) => any) {
+        this.target = target;
+        if (typeof original !== 'string') {
+            this.original = original as M;
+            this.key = Object.keys(target).find(key => target[key] === original);
+        } else {
+            this.original = undefined;
+            this.key = original as keyof T;
+        }
+        this.method = method;
+
+        Override.all.push(this);
+    }
+
+    apply() {
+        const {target, key, method, original} = this;
+        target[key] = function (...args) {
+            return method.apply(this, [original && original.bind(this), ...args]);
+        };
+    }
+
+    rollback() {
+        const {target, key, original} = this;
+        if (original) {
+            target[key] = original;
+        } else {
+            delete target[key];
+        }
+    }
+}


### PR DESCRIPTION
# What is it

In a private project (which is fully in typescript) i have added a way to easily override a functionality of kolbot, without the need to changing the files


# Example

```typescript
const override = new Override(Cubing, Cubing.openCube, function () {
    if (getUIFlag(0x1a)) return true;


    const cube = me.getItem(549);

    if (!cube) return false;

    if (cube.location === 7 && !Town.openStash()) return false;

    for (let i = 0; i < 3 && !getUIFlag(0x1a); i += 1) {
        cube.interact();
        Misc.poll(() => getUIFlag(0x1a))
        delay(300 + me.ping * 2); // allow UI to initialize
    }

    return getUIFlag(0x1a);
});

// now it will use the new Cubing.openCube function
override.apply(); 

// now it will use the original Cubing.openCube function
override.rollback();
```

# Special things
I often use it as a wrapper, doing so it can be very handy to have the actual original function. So, the first argument of the override function is the original. Example;

```typescript
new Override(Attack, Attack.clear, function (original, range = 25, spectype = 0, bossId = false, sortfunc = this.sortMonsters, pickit = true) {

    if (range > 10) {
        // call the original function which is being overriden
        return original(range, spectype, bossId, sortfunc, pickit);
    }

    // Do something specific for short range clears
});