### PR TITLE
Update Cows.js

### DIFF
--- a/d2bs/kolbot/libs/bots/Cows.js
+++ b/d2bs/kolbot/libs/bots/Cows.js
@@ -125,7 +125,7 @@ function Cows() {
 		typeof e === "object" && e.message && e.message !== "NOT PORTAL MAKER" && console.error(e);
 
 		if (Misc.getPlayerCount() > 1) {
-			!me.inTown && Town.goToTown(1);
+			Town.goToTown(1);
 			Town.move("stash");
 			console.log("ÿc9(Cows) :: ÿc0Waiting 1 minute to see if anyone else opens the cow portal");
 


### PR DESCRIPTION
If the character is started outside of A1 and is set as NOT the portal maker, it will wait indefinitely, removing the In Town check from before `Town.goToTown(1)` on line 128 resolves this.