### PR TITLE
Better recovery from errors during recursion, remove pointless delay

### DIFF
--- a/d2bs/kolbot/libs/common/AutoAssign.js
+++ b/d2bs/kolbot/libs/common/AutoAssign.js
@@ -237,9 +237,12 @@ const AutoAssign = {
 	updateNames: function (quitter) {
 		if (this.recursion) {
 			this.recursion = false;
-			quitter && this.removeNames(quitter);
-			this.getNames();
-			this.recursion = true;
+			try {
+				quitter && this.removeNames(quitter);
+				this.getNames();
+			} finally {
+				this.recursion = true;
+			}
 		}
 		return true;
 	}

--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -265,9 +265,12 @@ const Pather = {
 					if (!me.inTown) {
 						if (this.recursion) {
 							this.recursion = false;
-							NodeAction.go(settings.clearSettings);
-							node.distance > 5 && this.moveTo(node.x, node.y);
-							this.recursion = true;
+							try {
+								NodeAction.go(settings.clearSettings);
+								node.distance > 5 && this.moveTo(node.x, node.y);
+							} finally {
+								this.recursion = true;
+							}
 						}
 
 						settings.allowTown && Misc.townCheck();

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -1205,7 +1205,6 @@ const Town = {
 			chugs.forEach(function (pot) {
 				if (!!pot && pot.use()) {
 					quantity++;
-					delay(100 + pingDelay);
 				}
 			});
 

--- a/d2bs/kolbot/libs/manualplay/libs/PatherOverrides.js
+++ b/d2bs/kolbot/libs/manualplay/libs/PatherOverrides.js
@@ -339,14 +339,15 @@ Pather.moveTo = function (x, y, retry, clearPath, pop) {
 				if (!me.inTown) {
 					if (this.recursion) {
 						this.recursion = false;
+						try {
+							NodeAction.go(clearSettings);
 
-						NodeAction.go(clearSettings);
-
-						if (getDistance(me, node.x, node.y) > 5) {
-							this.moveTo(node.x, node.y);
+							if (getDistance(me, node.x, node.y) > 5) {
+								this.moveTo(node.x, node.y);
+							}
+						} finally {
+							this.recursion = true;
 						}
-
-						this.recursion = true;
 					}
 
 					Misc.townCheck();


### PR DESCRIPTION
The delay is not needed as pot.use() already does:

```
	if (checkQuantity) {
		return Misc.poll(() => this.getStat(sdk.stats.Quantity) < quantity, 200 + pingDelay, 50);
	} else {
		return Misc.poll(() => !Game.getItem(-1, -1, gid), 200 + pingDelay, 50);
	}
```

which either implies it already worked, or spent 200ms+ already.