### PR TITLE
Mule fixes

### DIFF
--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -851,7 +851,7 @@ function locationAction (location) {
 
 		break;
 	default:
-		if (location !== undefined) {
+		if (location !== undefined && location !== null) {
 			D2Bot.printToConsole("Unhandled location " + location);
 			delay(500);
 			D2Bot.restart();

--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -253,7 +253,7 @@ const Mule = {
 				// pick large items first by sorting items by size in descending order and move gheed's charm to the end of the list
 				list.sort(function(a, b) {
 					if (a.isGheeds && !Pickit.canPick(a)) return 1;
-					if (b.isGheeds && b.unique && !Pickit.canPick(b)) return -1;
+					if (b.isGheeds && !Pickit.canPick(b)) return -1;
 
 					return (b.sizex * b.sizey - a.sizex * a.sizey);
 				});
@@ -768,6 +768,7 @@ function main () {
 		D2Bot.printToConsole("DataFileException: " + e.message + " (" + e.fileName.substring(e.fileName.lastIndexOf("\\") + 1, e.fileName.length) + " #" + e.lineNumber + ")");
 	}
 
+	MainLoop:
 	while (true) {
 		try {
 			if (me.ingame && me.gameReady) {
@@ -870,7 +871,8 @@ function main () {
 							delay(100);
 						}
 
-						break;
+						// should fix hitting gameRefresh when making a new character
+						continue MainLoop;
 					case "fail":
 						// Try again
 						break;

--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -32,9 +32,10 @@ include("NTItemParser.dbl");
 include("NTItemAlias.dbl");
 include("common/util.js");
 includeCommonLibs();
+
 let Controls = require("./modules/Control");
 let Overrides = require("./modules/Override");
-const Worker = require("../../modules/Worker");
+const Worker = require("./modules/Worker");
 
 /** @global */
 let master, muleMode, muleFilename, muleObj, maxCharCount;
@@ -168,22 +169,23 @@ const Mule = {
 	},
 
 	init: function () {
+		Mule.startTick = getTickCount();
+
+		while ((getLocation() !== null) && !!me.area && getTickCount() - Mule.startTick < Time.seconds(10)) {
+			delay(200);
+		}
+
+		if (getLocation() !== null || !me.ingame || !me.gameReady || !me.inTown) {
+			return false;
+		}
+
 		Starter.firstLogin ? (Starter.firstLogin = false) : (status = "begin");
 		status !== "begin" && (status = "ready");
 		Mule.statusString = "In " + (muleMode === 2 ? "anni " : muleMode === 1 ? "torch " : "") + "mule game.";
 
 		D2Bot.updateStatus(Mule.statusString + " Status: " + status);
 		D2Bot.printToConsole(Mule.statusString, sdk.colors.D2Bot.DarkGold);
-		Mule.startTick = getTickCount();
 		Mule.recheckTick = getTickCount();
-
-		while ((getLocation() !== null || !me.area) && getTickCount() - Mule.startTick < 5000) {
-			delay(200);
-		}
-
-		if (!me.ingame || !me.gameReady || !me.inTown) {
-			return false;
-		}
 
 		Town.goToTown(1);
 		Town.move("stash");
@@ -191,6 +193,7 @@ const Mule = {
 		// Move away from stash so we don't block muler
 		let coord = {};
 		do {
+			delay(1000);
 			coord = CollMap.getRandCoordinate(me.x, -6, 6, me.y, -6, 6);
 		} while (!Attack.validSpot(coord.x, coord.y));
 
@@ -201,7 +204,9 @@ const Mule = {
 		Starter.inGame = true;
 		Mule.continuousMule && !muleObj.onlyLogWhenFull && MuleLogger.logChar();
 		// Worker.runInBackground.areaWatcher = Mule.areaWatcher; // bugs for some reason, quits game then on re-join d2bot spams In mule game for ~30seconds
-		Worker.runInBackground.antiIdle = Mule.antiIdle;
+		if (Worker.runInBackground.antiIdle === undefined) {
+			Worker.runInBackground.antiIdle = Mule.antiIdle;
+		}
 
 		return true;
 	},
@@ -225,7 +230,7 @@ const Mule = {
 	done: function () {
 		!muleObj.onlyLogWhenFull && MuleLogger.logChar();
 
-		obj = MuleData.read();
+		let obj = MuleData.read();
 
 		if (Mule.checkAnniTorch() && obj.torchChars.indexOf(me.name) === -1) {
 			obj.torchChars.push(me.name);
@@ -242,7 +247,7 @@ const Mule = {
 		delay(500);
 
 		[makeNext, checkOnJoin] = [true, true];
-		obj = MuleData.read();
+		let obj = MuleData.read();
 
 		if (Mule.checkAnniTorch() && obj.torchChars.indexOf(me.name) === -1) {
 			obj.torchChars.push(me.name);
@@ -312,17 +317,17 @@ const Mule = {
 		let tick = getTickCount();
 
 		while (getTickCount() - tick < time) {
-			if (me.ingame && me.gameReady) return true;
+			if (me.ingame && me.gameReady && !!me.area) break;
 
 			// game doesn't exist, might need more locs
-			if (getLocation() === 28) {
+			if (getLocation() === sdk.game.locations.GameDoesNotExist) {
 				break;
 			}
 
 			delay(100);
 		}
 
-		return me.ingame && me.gameReady;
+		return (me.ingame && me.gameReady && !!me.area);
 	},
 
 	foreverAlone: function () {
@@ -575,8 +580,11 @@ function locationAction (location) {
 		}
 
 		createGame(muleObj.muleGameName[0], muleObj.muleGameName[1]);
-		Mule.ingameTimeout(5000);
-
+		if (!Mule.ingameTimeout(Time.minutes(1))) {
+			console.debug("Failed to get in game, current location: " + getLocation() + " inGame? " + me.ingame + " area? " + me.area);
+			break;
+		}
+		
 		status = "pending";
 
 		break;
@@ -615,8 +623,9 @@ function locationAction (location) {
 
 		!Starter.firstLogin && (status = "pending");
 
-		Mule.ingameTimeout(5000);
-		print("Ingame timeout done.");
+		if (Mule.ingameTimeout(Time.minutes(1))) {
+			console.debug("Ingame timeout done.");
+		}
 
 		// could not join game
 		getLocation() === sdk.game.locations.Lobby && !me.ingame && Controls.CreateGameWindow.click();
@@ -863,13 +872,15 @@ function gameEvent (mode, param1, param2, name1, name2) {
 	case 0x00: // "%Name1(%Name2) dropped due to time out."
 	case 0x01: // "%Name1(%Name2) dropped due to errors."
 	case 0x03: // "%Name1(%Name2) left our world. Diablo's minions weaken."
-		print("Waiting");
-		status = "ready";
+		if (Mule.foreverAlone()) {
+			console.log("Waiting");
+			status = "ready";
+		}
 
 		break;
 	case 0x02: // "%Name1(%Name2) joined our world. Diablo's minions grow stronger."
 		if (name1.trim() !== me.name.trim()) {
-			print("begin");
+			console.log("begin");
 			status = "begin";
 		}
 
@@ -943,7 +954,8 @@ function main () {
 			if (me.ingame && me.gameReady) {
 				if (!Starter.inGame) {
 					if (!Mule.init()) {
-						console.debug("Failed to init. Trying again.");
+						console.debug("Failed to init. Trying again. Ingame and ready? " + (me.ingame && me.gameReady && !!me.area));
+						delay(1000);
 						continue;
 					}
 				}

--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -244,8 +244,8 @@ const Mule = {
 				}
 
 				// If and only if there is nothing left are we "done"
-				if (!Mule.continuousMule && list.length === 0) {
-					rval = "done";
+				if (list.length === 0) {
+					rval = Mule.continuousMule ? "ready" : "done";
 
 					break;
 				}
@@ -270,7 +270,7 @@ const Mule = {
 					}
 
 					// Gheed's Fortune handling
-					if (item.isGheeds && item.unique && !Pickit.canPick(item)) {
+					if (item.isGheeds && !Pickit.canPick(item)) {
 						D2Bot.printToConsole("Mule already has Gheed's.", sdk.colors.D2Bot.DarkGold);
 						rval = "next";
 					}
@@ -281,17 +281,12 @@ const Mule = {
 
 					if (canFit) {
 						Pickit.pickItem(item);
-
-						if (muleMode > 0 && Mule.continuousMule && item.unique
-						&& ([sdk.items.SmallCharm, sdk.items.LargeCharm, sdk.items.GrandCharm].includes(item.classid))) {
-							rval = "next";
-						}
 					} else {
 						rval = "next";
 					}
 				}
 
-				if (rval === "next" || Mule.continuousMule) {
+				if (rval === "next") {
 					break;
 				}
 			} else {
@@ -752,6 +747,7 @@ function main () {
 	print("Mule filename: " + muleFilename);
 
 	let obj, tick, statusString = "";
+	let recheckTick;
 
 	try {
 		// ugly solution to uglier problem - pickItem area update
@@ -780,6 +776,7 @@ function main () {
 					D2Bot.updateStatus(statusString + " Status: " + status);
 					D2Bot.printToConsole(statusString, sdk.colors.D2Bot.DarkGold);
 					tick = getTickCount();
+					recheckTick = getTickCount();
 
 					while ((getLocation() !== null || !me.area) && getTickCount() - tick < 5000) {
 						delay(200);
@@ -873,15 +870,22 @@ function main () {
 
 						// should fix hitting gameRefresh when making a new character
 						continue MainLoop;
+					case "ready":
+						recheckTick = getTickCount();
+
+						break;
 					case "fail":
 						// Try again
 						break;
 					}
 				}
 
-				if (Mule.continuousMule && Starter.Config.MaxGameTime > 0) {
-					if (getTickCount() - me.gamestarttime > Time.minutes(Starter.Config.MaxGameTime) && Mule.foreverAlone()) {
+				if (Mule.continuousMule) {
+					if (Starter.Config.MaxGameTime > 0 && getTickCount() - me.gamestarttime > Time.minutes(Starter.Config.MaxGameTime) && Mule.foreverAlone()) {
 						Mule.gameRefresh();
+					} else if (getTickCount() - recheckTick > Time.minutes(10)) {
+						// recheck every 10 minutes?
+						status = "begin";
 					}
 				}
 			}

--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -284,6 +284,9 @@ const Mule = {
 		return true;
 	},
 
+	/**
+	 * @todo handle when a bot wants to mule while we are refreshing the game
+	 */
 	gameRefresh: function () {
 		if (!this.continuousMule) return this.quit();
 		console.log("MaxGameTime Reached: ");
@@ -302,6 +305,9 @@ const Mule = {
 		return true;
 	},
 
+	/**
+	 * @param {number} time 
+	 */
 	ingameTimeout: function (time) {
 		let tick = getTickCount();
 
@@ -357,6 +363,7 @@ const Mule = {
 
 		if (cursorItem) {
 			if (!Storage.Inventory.CanFit(cursorItem) || !Storage.Inventory.MoveTo(cursorItem)) {
+				console.warn("Can't place " + cursorItem.prettyPrint + " in inventory");
 				cursorItem.drop();
 			}
 		}
@@ -417,7 +424,7 @@ const Mule = {
 				});
 
 				while (list.length > 0) {
-					const item = list.shift();
+					item = list.shift();
 					let canFit = Storage.Inventory.CanFit(item);
 
 					// Torch and Anni handling
@@ -523,7 +530,7 @@ new Overrides.Override (Starter, Starter.updateCount, function () {
 }).apply();
 
 function locationAction (location) {
-	let i, obj, info, string, text;
+	let obj, info, string, text;
 
 	switch (location) {
 	case sdk.game.locations.PreSplash:
@@ -677,7 +684,7 @@ function locationAction (location) {
 		text = Controls.CharSelectError.getText();
 
 		if (text) {
-			for (i = 0; i < text.length; i++) {
+			for (let i = 0; i < text.length; i++) {
 				string += text[i];
 
 				if (i !== text.length - 1) {
@@ -913,8 +920,6 @@ function main () {
 
 	console.log("Mule filename: " + muleFilename);
 
-	let obj;
-
 	try {
 		// ugly solution to uglier problem - pickItem area update
 		!FileTools.exists("data/" + me.profile + ".json") && DataFile.create();
@@ -922,9 +927,10 @@ function main () {
 		// create mule datafile if it doesn't exist
 		!FileTools.exists(muleFilename) && MuleData.create();
 
-		obj = MuleData.read();
+		let obj = MuleData.read();
 		obj.account && obj.account.indexOf(muleObj.accountPrefix) < 0 && MuleData.create();
 	} catch (e) {
+		// probably should try again if fails to make file or shut down instead of continuing loop
 		console.warn("Caught exception creating data files.");
 		console.error(e);
 		D2Bot.printToConsole("DataFileException: " + e.message + " (" + e.fileName.substring(e.fileName.lastIndexOf("\\") + 1, e.fileName.length) + " #" + e.lineNumber + ")");
@@ -974,7 +980,7 @@ function main () {
 				if (Mule.continuousMule) {
 					if (Starter.Config.MaxGameTime > 0 && getTickCount() - me.gamestarttime > Time.minutes(Starter.Config.MaxGameTime) && Mule.foreverAlone()) {
 						Mule.gameRefresh();
-					} else if (getTickCount() - recheckTick > Time.minutes(10)) {
+					} else if (getTickCount() - Mule.recheckTick > Time.minutes(10)) {
 						// recheck every 10 minutes?
 						status = "begin";
 					}

--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -34,13 +34,17 @@ include("common/util.js");
 includeCommonLibs();
 let Controls = require("./modules/Control");
 let Overrides = require("./modules/Override");
+const Worker = require("../../modules/Worker");
 
+/** @global */
 let master, muleMode, muleFilename, muleObj, maxCharCount;
 let [checkOnJoin, makeNext] = [false, false];
 let status = "loading";
 let masterStatus = { status: "" };
 
-// Mule Data object manipulates external mule datafile
+/**
+ * Mule Data object manipulates external mule datafile
+ */
 const MuleData = {
 	_default: {
 		account: "",
@@ -109,27 +113,181 @@ const MuleData = {
 const Mule = {
 	continuousMule: false,
 	clearedJunk: false,
+	startTick: 0,
+	idleTick: 0,
+	areaTick: 0,
+	recheckTick: 0,
+	statusString: "",
+
+	/**
+	 * @description background worker to prevent idle disconnect
+	 */
+	antiIdle: function () {
+		if (!Starter.inGame) return true;
+		if (!me.ingame || getTickCount() - me.gamestarttime < Time.minutes(1) || !me.gameReady) return true;
+		if (Mule.idleTick === 0) {
+			Mule.idleTick = getTickCount() + Time.seconds(rand(1200, 1500));
+			console.log("Game start, anti-idle refresh in: (" + Time.format(Mule.idleTick - getTickCount()) + ")");
+		}
+		if (me.gameReady) {
+			if (getTickCount() - Mule.idleTick > 0) {
+				Packet.questRefresh();
+				Mule.idleTick += Time.seconds(rand(1200, 1500));
+				console.log("Sent anti-idle packet, next refresh in: (" + Time.format(Mule.idleTick - getTickCount()) + ")");
+			}
+		} else if (getLocation() !== null) {
+			Mule.idleTick = 0;
+		}
+
+		return true;
+	},
+
+	/**
+	 * @description background worker to prevent suicide walks
+	 * @todo figure out why this bugs out when used
+	 */
+	areaWatcher: function () {
+		if (!Starter.inGame) return true;
+		// run area check every half second
+		if (getTickCount() - Mule.areaTick < 500) return true;
+		Mule.areaTick = getTickCount();
+		// check that we are actually in game and that we've been there longer than a minute
+		if (getLocation() !== null || getTickCount() - me.gamestarttime < Time.minutes(1)) return true;
+		console.debug("Check Area: " + me.area);
+
+		if (me.ingame && me.gameReady && me.area > 0) {
+			if (me.area !== sdk.areas.RogueEncampment) {
+				console.warn("Preventing Suicide Walk! Current Area: " + me.area);
+				console.trace();
+
+				Mule.quit();
+			}
+		}
+
+		return true;
+	},
+
+	init: function () {
+		Starter.firstLogin ? (Starter.firstLogin = false) : (status = "begin");
+		status !== "begin" && (status = "ready");
+		Mule.statusString = "In " + (muleMode === 2 ? "anni " : muleMode === 1 ? "torch " : "") + "mule game.";
+
+		D2Bot.updateStatus(Mule.statusString + " Status: " + status);
+		D2Bot.printToConsole(Mule.statusString, sdk.colors.D2Bot.DarkGold);
+		Mule.startTick = getTickCount();
+		Mule.recheckTick = getTickCount();
+
+		while ((getLocation() !== null || !me.area) && getTickCount() - Mule.startTick < 5000) {
+			delay(200);
+		}
+
+		if (!me.ingame || !me.gameReady || !me.inTown) {
+			return false;
+		}
+
+		Town.goToTown(1);
+		Town.move("stash");
+
+		// Move away from stash so we don't block muler
+		let coord = {};
+		do {
+			coord = CollMap.getRandCoordinate(me.x, -6, 6, me.y, -6, 6);
+		} while (!Attack.validSpot(coord.x, coord.y));
+
+		Pather.moveToUnit(coord);
+					
+		Storage.Init();
+		checkOnJoin && (status = "begin");
+		Starter.inGame = true;
+		Mule.continuousMule && !muleObj.onlyLogWhenFull && MuleLogger.logChar();
+		// Worker.runInBackground.areaWatcher = Mule.areaWatcher; // bugs for some reason, quits game then on re-join d2bot spams In mule game for ~30seconds
+		Worker.runInBackground.antiIdle = Mule.antiIdle;
+
+		return true;
+	},
+
+	waitForMaster: function () {
+		console.log("Waiting for muler");
+		// forever alone check?
+		Misc.poll(() => status === "begin", Time.minutes(3), 100);
+
+		if (status !== "begin") {
+			D2Bot.printToConsole("Nobody joined - stopping.", sdk.colors.D2Bot.Red);
+			D2Bot.stop(me.profile, true);
+		}
+
+		me.overhead("begin");
+	},
+
+	/**
+	 * @todo check if there are any other profiles that need to mule while we are already in game?
+	 */
+	done: function () {
+		!muleObj.onlyLogWhenFull && MuleLogger.logChar();
+
+		obj = MuleData.read();
+
+		if (Mule.checkAnniTorch() && obj.torchChars.indexOf(me.name) === -1) {
+			obj.torchChars.push(me.name);
+		}
+
+		MuleData.write(obj);
+		D2Bot.printToConsole("Done muling.", sdk.colors.D2Bot.DarkGold);
+		sendCopyData(null, master, 10, JSON.stringify({ status: "quit" }));
+		D2Bot.stop(me.profile, true);
+	},
+
+	next: function () {
+		MuleLogger.logChar();
+		delay(500);
+
+		[makeNext, checkOnJoin] = [true, true];
+		obj = MuleData.read();
+
+		if (Mule.checkAnniTorch() && obj.torchChars.indexOf(me.name) === -1) {
+			obj.torchChars.push(me.name);
+		}
+
+		obj.fullChars.push(me.name);
+		MuleData.write(obj);
+		MuleData.nextChar();
+		D2Bot.printToConsole("Mule full, getting next character.", sdk.colors.D2Bot.DarkGold);
+
+		if (Starter.Config.MinGameTime && getTickCount() - Mule.startTick < Starter.Config.MinGameTime * 1000) {
+			while (getTickCount() - Mule.startTick < Starter.Config.MinGameTime * 1000) {
+				me.overhead("Stalling for " + Math.round(((Mule.startTick + (Starter.Config.MinGameTime * 1000)) - getTickCount()) / 1000) + " Seconds");
+				delay(1000);
+			}
+		}
+
+		Mule.quit();
+	},
 	
 	quit: function () {
 		["default.dbj", "tools/AntiIdle.js", "tools/AreaWatcher.js"].forEach(thread => {
 			let script = getScript(thread);
-			!!script && script.running && script.stop();
-			delay(100);
+			if (script && script.running && script.stop()) {
+				delay(100);
+			}
 		});
 		Mule.cursorCheck();
-		quit();
+		console.log("ÿc8Mule game duration ÿc2" + (Time.format(getTickCount() - me.gamestarttime)));
+
+		try {
+			quit();
+		} finally {
+			while (me.ingame) {
+				delay(100);
+			}
+		}
 
 		return true;
 	},
 
 	gameRefresh: function () {
 		if (!this.continuousMule) return this.quit();
-		console.log("MaxGameTime Reached");
+		console.log("MaxGameTime Reached: ");
 		Mule.quit();
-						
-		while (me.ingame) {
-			delay(100);
-		}
 						
 		Starter.firstLogin = true;
 		console.log("updating runs");
@@ -140,6 +298,7 @@ const Mule = {
 		delay(1000);
 		Controls.LobbyQuit.click(); // Quit from Lobby
 		ControlAction.timeoutDelay("Refresh game", 330 * 1000); // 5.5 minutes
+
 		return true;
 	},
 
@@ -207,7 +366,6 @@ const Mule = {
 
 	pickItems: function () {
 		let waitTick = getTickCount();
-		let canFit, item;
 		let rval = "fail";
 		let list = [];
 
@@ -218,7 +376,7 @@ const Mule = {
 
 		if (!Mule.clearedJunk) {
 			me.getItemsEx()
-				.filter(item => item.isInInventory && Town.ignoredItemTypes.includes(item.itemType) && (muleMode === 0 || item.classid !== sdk.items.ScrollofIdentify))
+				.filter(item => item.isInInventory && Town.ignoreType(item.itemType) && (muleMode === 0 || item.classid !== sdk.items.ScrollofIdentify))
 				.forEach(item => {
 					try {
 						item.drop();
@@ -232,12 +390,12 @@ const Mule = {
 		while (me.gameReady) {
 			if (masterStatus.status === "done" || Mule.continuousMule || checkOnJoin) {
 				checkOnJoin && (checkOnJoin = false);
-				item = Game.getItem();
+				let item = Game.getItem();
 
 				if (item) {
 					do {
 					// don't pick up trash
-						if (item.distance < 20 && item.onGroundOrDropping && Town.ignoredItemTypes.indexOf(item.itemType) === -1) {
+						if (item.distance < 20 && item.onGroundOrDropping && !Town.ignoreType(item.itemType)) {
 							list.push(copyUnit(item));
 						}
 					} while (item.getNext());
@@ -259,8 +417,8 @@ const Mule = {
 				});
 
 				while (list.length > 0) {
-					item = list.shift();
-					canFit = Storage.Inventory.CanFit(item);
+					const item = list.shift();
+					let canFit = Storage.Inventory.CanFit(item);
 
 					// Torch and Anni handling
 					if (muleMode > 0 && item.unique && [sdk.items.SmallCharm, sdk.items.LargeCharm].includes(item.classid) && !Pickit.canPick(item)) {
@@ -431,6 +589,13 @@ function locationAction (location) {
 		if (!Mule.continuousMule) {
 			D2Bot.requestGame(master);
 			delay(100);
+		}
+
+		if (Starter.inGame) {
+			print("updating runs");
+			D2Bot.updateRuns();
+			status = "ready";
+			Starter.inGame = false;
 		}
 
 		delay(2000);
@@ -706,6 +871,7 @@ function gameEvent (mode, param1, param2, name1, name2) {
 }
 
 function main () {
+	// basics -- don't touch
 	addEventListener("copydata", Starter.receiveCopyData);
 
 	while (!Starter.handle) {
@@ -724,6 +890,7 @@ function main () {
 	D2Bot.updateRuns(); // we need the mule to swap keys somehow after all
 	delay(1000);
 
+	// mule/master data initialization block 
 	Mule.continuousMule = AutoMule.isContinousMule();
 
 	if (Mule.continuousMule) {
@@ -738,16 +905,15 @@ function main () {
 			delay(100);
 		}
 
-		print("Master found: " + master);
+		console.log("Master found: " + master);
 
 		muleObj = AutoMule.getMuleObject(muleMode, master);
 		muleFilename = AutoMule.getMuleFilename(muleMode, master);
 	}
 
-	print("Mule filename: " + muleFilename);
+	console.log("Mule filename: " + muleFilename);
 
-	let obj, tick, statusString = "";
-	let recheckTick;
+	let obj;
 
 	try {
 		// ugly solution to uglier problem - pickItem area update
@@ -764,114 +930,39 @@ function main () {
 		D2Bot.printToConsole("DataFileException: " + e.message + " (" + e.fileName.substring(e.fileName.lastIndexOf("\\") + 1, e.fileName.length) + " #" + e.lineNumber + ")");
 	}
 
+	// begin
 	MainLoop:
 	while (true) {
 		try {
 			if (me.ingame && me.gameReady) {
 				if (!Starter.inGame) {
-					Starter.firstLogin ? (Starter.firstLogin = false) : (status = "begin");
-					status !== "begin" && (status = "ready");
-					statusString = "In " + (muleMode === 2 ? "anni " : muleMode === 1 ? "torch " : "") + "mule game.";
-
-					D2Bot.updateStatus(statusString + " Status: " + status);
-					D2Bot.printToConsole(statusString, sdk.colors.D2Bot.DarkGold);
-					tick = getTickCount();
-					recheckTick = getTickCount();
-
-					while ((getLocation() !== null || !me.area) && getTickCount() - tick < 5000) {
-						delay(200);
-					}
-
-					if (!me.ingame || !me.gameReady || !me.inTown) {
+					if (!Mule.init()) {
+						console.debug("Failed to init. Trying again.");
 						continue;
 					}
-
-					Town.goToTown(1);
-					Town.move("stash");
-
-					// Move away from stash so we don't block muler
-					let coord = {};
-					do {
-						coord = CollMap.getRandCoordinate(me.x, -6, 6, me.y, -6, 6);
-					} while (!Attack.validSpot(coord.x, coord.y));
-
-					Pather.moveTo(coord.x, coord.y);
-					
-					Storage.Init();
-					checkOnJoin && (status = "begin");
-					Starter.inGame = true;
-					Mule.continuousMule && !muleObj.onlyLogWhenFull && MuleLogger.logChar();
 				}
 
 				if (!Mule.continuousMule) {
-					console.log("Waiting for muler");
-					// forever alone check?
-					Misc.poll(() => status === "begin", Time.minutes(3), 100);
-
-					if (status !== "begin") {
-						D2Bot.printToConsole("Nobody joined - stopping.", sdk.colors.D2Bot.Red);
-						D2Bot.stop(me.profile, true);
-					}
-
-					me.overhead("begin");
+					Mule.waitForMaster();
 				}
 
-				D2Bot.updateStatus(statusString + " Status: " + status + Starter.timer(me.gamestarttime));
+				D2Bot.updateStatus(Mule.statusString + " Status: " + status + Starter.timer(me.gamestarttime));
 
 				if (status === "begin") {
 					switch (Mule.pickItems()) {
 					// done picking, tell the master to leave game and kill mule profile
 					case "done":
-						!muleObj.onlyLogWhenFull && MuleLogger.logChar();
-
-						obj = MuleData.read();
-
-						if (Mule.checkAnniTorch() && obj.torchChars.indexOf(me.name) === -1) {
-							obj.torchChars.push(me.name);
-						}
-
-						MuleData.write(obj);
-						// check if there are any other profiles that need to mule while we are already in game?
-						D2Bot.printToConsole("Done muling.", sdk.colors.D2Bot.DarkGold);
-						sendCopyData(null, master, 10, JSON.stringify({ status: "quit" }));
-						D2Bot.stop(me.profile, true);
+						Mule.done();
 
 						return;
 					// can't fit more items, get to next character or account
 					case "next":
-						MuleLogger.logChar();
-						delay(500);
-
-						[makeNext, checkOnJoin] = [true, true];
-						obj = MuleData.read();
-
-						if (Mule.checkAnniTorch() && obj.torchChars.indexOf(me.name) === -1) {
-							obj.torchChars.push(me.name);
-						}
-
-						obj.fullChars.push(me.name);
-						MuleData.write(obj);
-						MuleData.nextChar();
-						D2Bot.printToConsole("Mule full, getting next character.", sdk.colors.D2Bot.DarkGold);
-
-						if (Starter.Config.MinGameTime && getTickCount() - tick < Starter.Config.MinGameTime * 1000) {
-							while (getTickCount() - tick < Starter.Config.MinGameTime * 1000) {
-								me.overhead("Stalling for " + Math.round(((tick + (Starter.Config.MinGameTime * 1000)) - getTickCount()) / 1000) + " Seconds");
-								delay(1000);
-							}
-						}
-
-						Mule.quit();
-
-						// TODO: see whether a for loop is better
-						while (me.ingame) {
-							delay(100);
-						}
+						Mule.next();
 
 						// should fix hitting gameRefresh when making a new character
 						continue MainLoop;
 					case "ready":
-						recheckTick = getTickCount();
+						Mule.recheckTick = getTickCount();
 
 						break;
 					case "fail":
@@ -888,9 +979,7 @@ function main () {
 						status = "begin";
 					}
 				}
-			}
-
-			if (!me.ingame) {
+			} else if (!me.ingame) {
 				delay(1000);
 				locationAction(getLocation());
 			}

--- a/d2bs/kolbot/D2BotMule.dbj
+++ b/d2bs/kolbot/D2BotMule.dbj
@@ -42,19 +42,17 @@ let masterStatus = { status: "" };
 
 // Mule Data object manipulates external mule datafile
 const MuleData = {
+	_default: {
+		account: "",
+		accNum: 0,
+		character: "",
+		charNum: 0,
+		fullChars: [],
+		torchChars: []
+	},
 	// create a new mule datafile
 	create: function () {
-		let obj = {
-			account: "",
-			accNum: 0,
-			character: "",
-			charNum: 0,
-			fullChars: [],
-			torchChars: []
-		};
-
-		let string = JSON.stringify(obj);
-
+		let string = JSON.stringify(this._default);
 		FileTools.writeText(muleFilename, string);
 	},
 
@@ -76,14 +74,10 @@ const MuleData = {
 	nextAccount: function () {
 		let obj = MuleData.read();
 
-		obj.accNum = obj.accNum + 1;
+		obj.accNum += 1;
 		obj.account = muleObj.accountPrefix + obj.accNum;
-		obj.character = "";
-		obj.charNum = 0;
-		obj.fullChars = [];
-		obj.torchChars = [];
 
-		MuleData.write(obj);
+		MuleData.write(Object.assign(this._default, { accNum: obj.accNum, account: obj.account }));
 
 		return obj.account;
 	},
@@ -258,8 +252,8 @@ const Mule = {
 
 				// pick large items first by sorting items by size in descending order and move gheed's charm to the end of the list
 				list.sort(function(a, b) {
-					if (a.classid === sdk.items.GrandCharm && a.unique && !Pickit.canPick(a)) return 1;
-					if (b.classid === sdk.items.GrandCharm && b.unique && !Pickit.canPick(b)) return -1;
+					if (a.isGheeds && !Pickit.canPick(a)) return 1;
+					if (b.isGheeds && b.unique && !Pickit.canPick(b)) return -1;
 
 					return (b.sizex * b.sizey - a.sizex * a.sizey);
 				});
@@ -268,24 +262,16 @@ const Mule = {
 					item = list.shift();
 					canFit = Storage.Inventory.CanFit(item);
 
-					// Torch handling
-					if (muleMode > 0 && item.classid === sdk.items.LargeCharm && item.unique && !Pickit.canPick(item)) {
-						D2Bot.printToConsole("Mule already has a Torch.", sdk.colors.D2Bot.DarkGold);
-
-						rval = "next";
-					}
-
-					// Anni handling
-					if (muleMode > 0 && item.classid === sdk.items.SmallCharm && item.unique && !Pickit.canPick(item)) {
-						D2Bot.printToConsole("Mule already has an Anni.", sdk.colors.D2Bot.DarkGold);
-
+					// Torch and Anni handling
+					if (muleMode > 0 && item.unique && [sdk.items.SmallCharm, sdk.items.LargeCharm].includes(item.classid) && !Pickit.canPick(item)) {
+						let msg = item.classid === sdk.items.LargeCharm ? "Mule already has a Torch." : "Mule already has a Anni.";
+						D2Bot.printToConsole(msg, sdk.colors.D2Bot.DarkGold);
 						rval = "next";
 					}
 
 					// Gheed's Fortune handling
-					if (item.classid === sdk.items.GrandCharm && item.unique && !Pickit.canPick(item)) {
+					if (item.isGheeds && item.unique && !Pickit.canPick(item)) {
 						D2Bot.printToConsole("Mule already has Gheed's.", sdk.colors.D2Bot.DarkGold);
-
 						rval = "next";
 					}
 
@@ -362,8 +348,6 @@ new Overrides.Override (Starter, Starter.receiveCopyData, function (orignal, mod
 		break;
 	default:
 		orignal(mode, msg);
-
-		break;
 	}
 }).apply();
 
@@ -407,11 +391,9 @@ function locationAction (location) {
 
 		if (makeNext) {
 			Controls.LobbyQuit.click();
-
-			break;
+		} else {
+			Starter.LocationEvents.openJoinGameWindow();
 		}
-
-		Starter.LocationEvents.openJoinGameWindow();
 
 		break;
 	case sdk.game.locations.CreateGame:
@@ -703,6 +685,7 @@ function locationAction (location) {
 	}
 }
 
+// item event check instead?
 // eslint-disable-next-line no-unused-vars
 function gameEvent (mode, param1, param2, name1, name2) {
 	if (!me.ingame || !me.gameReady || !me.name) {
@@ -742,20 +725,14 @@ function main () {
 		D2Bot.requestGameInfo();
 		delay(500);
 	}
-
-	if (Starter.gameInfo.rdBlocker) {
-		D2Bot.printToConsole("You must disable RD Blocker for Mule Logger to work properly. Stopping.");
-		D2Bot.stop(me.profile, true);
-
-		return;
-	}
-
+	
 	D2Bot.updateRuns(); // we need the mule to swap keys somehow after all
 	delay(1000);
 
 	Mule.continuousMule = AutoMule.isContinousMule();
 
 	if (Mule.continuousMule) {
+		console.log("Continuous Mule Mode Started");
 		muleMode = AutoMule.getMuleMode();
 		muleObj = AutoMule.getMuleObject(muleMode, "", true);
 		muleFilename = AutoMule.getMuleFilename(muleMode, "", true);
@@ -795,7 +772,7 @@ function main () {
 		try {
 			if (me.ingame && me.gameReady) {
 				if (!Starter.inGame) {
-					Starter.firstLogin && (Starter.firstLogin = false);
+					Starter.firstLogin ? (Starter.firstLogin = false) : (status = "begin");
 					status !== "begin" && (status = "ready");
 					statusString = "In " + (muleMode === 2 ? "anni " : muleMode === 1 ? "torch " : "") + "mule game.";
 
@@ -807,12 +784,20 @@ function main () {
 						delay(200);
 					}
 
+					if (!me.ingame || !me.gameReady || !me.inTown) {
+						continue;
+					}
+
 					Town.goToTown(1);
 					Town.move("stash");
 
 					// Move away from stash so we don't block muler
-					let coord = CollMap.getRandCoordinate(me.x, -6, 6, me.y, -6, 6);
-					!!coord && Attack.validSpot(coord.x, coord.y) && Pather.moveTo(coord.x, coord.y);
+					let coord = {};
+					do {
+						coord = CollMap.getRandCoordinate(me.x, -6, 6, me.y, -6, 6);
+					} while (!Attack.validSpot(coord.x, coord.y));
+
+					Pather.moveTo(coord.x, coord.y);
 					
 					Storage.Init();
 					checkOnJoin && (status = "begin");
@@ -822,15 +807,8 @@ function main () {
 
 				if (!Mule.continuousMule) {
 					console.log("Waiting for muler");
-					tick = getTickCount();
-
-					while (getTickCount() - tick < Time.minutes(1)) {
-						if (status === "begin") {
-							break;
-						}
-
-						delay(100);
-					}
+					// forever alone check?
+					Misc.poll(() => status === "begin", Time.minutes(3), 100);
 
 					if (status !== "begin") {
 						D2Bot.printToConsole("Nobody joined - stopping.", sdk.colors.D2Bot.Red);
@@ -840,7 +818,7 @@ function main () {
 					me.overhead("begin");
 				}
 
-				D2Bot.updateStatus(statusString + Starter.timer(me.gamestarttime));
+				D2Bot.updateStatus(statusString + " Status: " + status + Starter.timer(me.gamestarttime));
 
 				if (status === "begin") {
 					switch (Mule.pickItems()) {
@@ -855,6 +833,7 @@ function main () {
 						}
 
 						MuleData.write(obj);
+						// check if there are any other profiles that need to mule while we are already in game?
 						D2Bot.printToConsole("Done muling.", sdk.colors.D2Bot.DarkGold);
 						sendCopyData(null, master, 10, JSON.stringify({ status: "quit" }));
 						D2Bot.stop(me.profile, true);

--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -23,6 +23,13 @@ function main () {
 	D2Bot.init(); // Get D2Bot# handle
 	D2Bot.ingame();
 
+	(function (global, original) {
+		global.load = function (...args) {
+			original.apply(this, args);
+			delay(500);
+		};
+	})([].filter.constructor("return this")(), load);
+
 	// wait until game is ready
 	while (!me.gameReady) {
 		delay(50);
@@ -71,6 +78,7 @@ function main () {
 	let startTime = getTickCount();
 
 	this.scriptEvent = function (msg) {
+		if (msg === "quit") return;
 		if (typeof msg === "string" && msg === "soj") {
 			sojPause = true;
 			sojCounter = 0;
@@ -242,6 +250,8 @@ function main () {
 		}
 	}
 
+	removeEventListener("scriptmsg", this.scriptEvent);
+
 	AutoMule.muleCheck() && scriptBroadcast("mule");
 	CraftingSystem.checkFullSets() && scriptBroadcast("crafting");
 	TorchSystem.keyCheck() && scriptBroadcast("torch");
@@ -252,6 +262,8 @@ function main () {
 	if (anni && !Storage.Inventory.IsLocked(anni, Config.Inventory) && AutoMule.getInfo() && AutoMule.getInfo().hasOwnProperty("torchMuleInfo")) {
 		scriptBroadcast("muleAnni");
 	}
+
+	removeEventListener("copydata", this.copyDataEvent);
 
 	scriptBroadcast("quit");
 

--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -66,7 +66,6 @@ function main () {
 	if (getScript("D2BotDropper.dbj") || getScript("D2BotMule.dbj")) {
 		FileTools.exists("libs/ItemDB.js") && include("ItemDB.js");
 		load("tools/AreaWatcher.js");
-		// load("tools/AntiIdle.js");
 		
 		while (true) {
 			delay(1000);

--- a/d2bs/kolbot/default.dbj
+++ b/d2bs/kolbot/default.dbj
@@ -64,9 +64,9 @@ function main () {
 	
 	// don't load default for dropper/mules
 	if (getScript("D2BotDropper.dbj") || getScript("D2BotMule.dbj")) {
-		include("ItemDB.js");
+		FileTools.exists("libs/ItemDB.js") && include("ItemDB.js");
 		load("tools/AreaWatcher.js");
-		load("tools/AntiIdle.js");
+		// load("tools/AntiIdle.js");
 		
 		while (true) {
 			delay(1000);

--- a/d2bs/kolbot/libs/AutoMule.js
+++ b/d2bs/kolbot/libs/AutoMule.js
@@ -502,6 +502,7 @@ const AutoMule = {
 		AutoMule.gids = items.map(i => i.gid);
 
 		D2Bot.printToConsole("AutoMule: Transfering " + items.length + " items.", sdk.colors.D2Bot.DarkGold);
+		D2Bot.printToConsole("AutoMule: " + JSON.stringify(items.map(i => i.prettyPrint)), sdk.colors.D2Bot.DarkGold);
 		
 		items.forEach(item => item.drop());
 		delay(1000);

--- a/d2bs/kolbot/libs/Polyfill.js
+++ b/d2bs/kolbot/libs/Polyfill.js
@@ -145,9 +145,11 @@ if (!Array.prototype.remove) {
 	};
 }
 
-String.prototype.startsWith = function (prefix) {
-	return !prefix || this.substring(0, prefix.length) === prefix;
-};
+if (!String.prototype.startsWith) {
+	String.prototype.startsWith = function (prefix) {
+		return !prefix || this.substring(0, prefix.length) === prefix;
+	};
+}
 
 if (!String.prototype.endsWith) {
 	String.prototype.endsWith = function (search, this_len) {
@@ -157,6 +159,20 @@ if (!String.prototype.endsWith) {
 		return this.substring(this_len - search.length, this_len) === search;
 	};
 }
+
+if (!String.isEqual) {
+	/**
+	 * Check if two strings are equal
+	 * @static
+	 * @param {string} str1 
+	 * @param {string} str2 
+	 * @returns {boolean}
+	 */
+	String.isEqual = function (str1, str2) {
+		return str1.toLowerCase() === str2.toLowerCase();
+	};
+}
+
 // Production steps of ECMA-262, Edition 6, 22.1.2.1
 if (!Array.from) {
 	Array.from = (function () {
@@ -241,46 +257,69 @@ if (!Array.from) {
 }
 
 // Filter null or undefined objects in array
-Array.prototype.filterNull = function () {
-	return this.filter(x => x);
-};
+if (!Array.prototype.filterNull) {
+	Array.prototype.filterNull = function () {
+		return this.filter(x => x);
+	};
+}
 
 // Map the objects with the callback function and filter null values after mapping.
-Array.prototype.compactMap = function (callback) {
-	return this.map((x, i, array) => {
-		if (x == null) {
-			return null;
-		}
-		return callback(x, i, array);
-	})
-		.filterNull();
-};
+if (!Array.prototype.compactMap) {
+	Array.prototype.compactMap = function (callback) {
+		return this.map((x, i, array) => {
+			if (x == null) {
+				return null;
+			}
+			return callback(x, i, array);
+		})
+			.filterNull();
+	};
+}
 
 // Returns a random object in array
-Array.prototype.random = function () {
-	return this[Math.floor((Math.random() * this.length))];
-};
+if (!Array.prototype.random) {
+	Array.prototype.random = function () {
+		return this[Math.floor((Math.random() * this.length))];
+	};
+}
 
-Array.prototype.includes = function (e) {
-	return this.indexOf(e) > -1;
-};
+if (!Array.prototype.includes) {
+	Array.prototype.includes = function (e) {
+		return this.indexOf(e) > -1;
+	};
+}
+
+if (!Array.prototype.at) {
+	Array.prototype.at = function (pos) {
+		if (pos < 0) {
+			pos += this.length;
+		}
+		if (pos < 0 || pos >= this.length) return undefined;
+		return this[pos];
+	};
+}
 
 Array.prototype.contains = Array.prototype.includes;
 
-Array.prototype.intersection = function (other) {
-	return this.filter(e => other.includes(e));
-};
+if (!Array.prototype.intersection) {
+	Array.prototype.intersection = function (other) {
+		return this.filter(e => other.includes(e));
+	};
+}
 
-Array.prototype.difference = function (other) {
-	return this.filter(e => !other.includes(e));
-};
+if (!Array.prototype.difference) {
+	Array.prototype.difference = function (other) {
+		return this.filter(e => !other.includes(e));
+	};
+}
 
-Array.prototype.symmetricDifference = function (other) {
-	return this
-		.filter(e => !other.includes(e))
-		.concat(other.filter(e => !this.includes(e)));
-};
-
+if (!Array.prototype.symmetricDifference) {
+	Array.prototype.symmetricDifference = function (other) {
+		return this
+			.filter(e => !other.includes(e))
+			.concat(other.filter(e => !this.includes(e)));
+	};
+}
 
 // Returns a random integer between start and end included.
 Math.randomIntBetween = function (start, end) {
@@ -291,31 +330,35 @@ Math.randomIntBetween = function (start, end) {
 
 // Shuffle Array
 // http://stackoverflow.com/questions/6274339/how-can-i-shuffle-an-array-in-javascript
-Array.prototype.shuffle = function () {
-	let temp, index,
-		counter = this.length;
+if (!Array.prototype.shuffle) {
+	Array.prototype.shuffle = function () {
+		let temp, index;
+		let counter = this.length;
 
-	// While there are elements in the array
-	while (counter > 0) {
-		// Pick a random index
-		index = Math.floor(Math.random() * counter);
+		// While there are elements in the array
+		while (counter > 0) {
+			// Pick a random index
+			index = Math.floor(Math.random() * counter);
 
-		// Decrease counter by 1
-		counter -= 1;
+			// Decrease counter by 1
+			counter -= 1;
 
-		// And swap the last element with it
-		temp = this[counter];
-		this[counter] = this[index];
-		this[index] = temp;
-	}
+			// And swap the last element with it
+			temp = this[counter];
+			this[counter] = this[index];
+			this[index] = temp;
+		}
 
-	return this;
-};
+		return this;
+	};
+}
 
 // Trim String
-String.prototype.trim = function () {
-	return this.replace(/^\s+|\s+$/g, "");
-};
+if (!String.prototype.trim) {
+	String.prototype.trim = function () {
+		return this.replace(/^\s+|\s+$/g, "");
+	};
+}
 
 // Object.assign polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 if (typeof Object.assign !== "function") {

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -2172,6 +2172,24 @@ Object.defineProperties(Unit.prototype, {
 			return [sdk.items.type.Shield, sdk.items.type.AuricShields, sdk.items.type.VoodooHeads].includes(this.itemType);
 		},
 	},
+	isAnni: {
+		get: function () {
+			if (this.type !== sdk.unittype.Item) return false;
+			return this.unique && this.itemType === sdk.items.type.SmallCharm;
+		},
+	},
+	isTorch: {
+		get: function () {
+			if (this.type !== sdk.unittype.Item) return false;
+			return this.unique && this.itemType === sdk.items.type.LargeCharm;
+		},
+	},
+	isGheeds: {
+		get: function () {
+			if (this.type !== sdk.unittype.Item) return false;
+			return this.unique && this.itemType === sdk.items.type.GrandCharm;
+		},
+	},
 });
 
 Unit.prototype.hasEnchant = function (...enchants) {

--- a/d2bs/kolbot/libs/common/Prototypes.js
+++ b/d2bs/kolbot/libs/common/Prototypes.js
@@ -2190,6 +2190,12 @@ Object.defineProperties(Unit.prototype, {
 			return this.unique && this.itemType === sdk.items.type.GrandCharm;
 		},
 	},
+	prettyPrint: {
+		get: function () {
+			if (this.type !== sdk.unittype.Item) return this.name;
+			return this.fname.split("\n").reverse().join(" ");
+		}
+	},
 });
 
 Unit.prototype.hasEnchant = function (...enchants) {

--- a/d2bs/kolbot/libs/common/Town.js
+++ b/d2bs/kolbot/libs/common/Town.js
@@ -89,6 +89,10 @@ const Town = {
 		sdk.items.type.AntidotePotion, sdk.items.type.ThawingPotion
 	],
 
+	ignoreType: function (type) {
+		return Town.ignoredItemTypes.includes(type);
+	},
+
 	needPotions: function () {
 		// we aren't using MinColumn if none of the values are set
 		if (!Config.MinColumn.some(el => el > 0)) return false;


### PR DESCRIPTION
- A lot of general clean up and refactoring variables/functions out of the global scope in D2BotMule.dbj
- Use background worker to handle antiIdle
- More checks and error handling to ensure mule functions smoothly
- Fixed a bug where continuous mules would get reset to waiting when a muler left the game but others were still muling
- Print the items that are going to be muled to the console
- added prettyPrint prototype
- added full game handler for muler
- keep track of the items we dropped as a muler so we know when we are doing in case other muler's are in game as well
- added String.isEqual prototype to fix repeated
```js
 if ("someString".toLowerCase() === "someOtherString".toLowerCase())
 ```
 - added Town.ignoreType(itemType) to fix repeated
 ```js
 if (Town.ignoredItemTypes.indexOf(item.itemType) === -1)
 ```