### PR TITLE
fix typos

### DIFF
--- a/d2bs/kolbot/libs/OOG.js
+++ b/d2bs/kolbot/libs/OOG.js
@@ -1743,8 +1743,8 @@ const Starter = {
 				}
 
 				switch (string) {
-				case getLocaleString(sdk.locale.text.UsenameIncludedIllegalChars):
-				case getLocaleString(sdk.locale.text.UsenameIncludedDisallowedwords):
+				case getLocaleString(sdk.locale.text.UsernameIncludedIllegalChars):
+				case getLocaleString(sdk.locale.text.UsernameIncludedDisallowedwords):
 				case getLocaleString(sdk.locale.text.UsernameMustBeAtLeast):
 				case getLocaleString(sdk.locale.text.PasswordMustBeAtLeast):
 				case getLocaleString(sdk.locale.text.AccountMustBeAtLeast):


### PR DESCRIPTION
fix

> [Strict Warning] Code(162) File(c:\program files\kolbot2\d2bs\kolbot\libs\oog.js:1743) reference to undefined property sdk.locale.text.UsenameIncludedIllegalChars