### PR TITLE
Issue 390: Weapons not switching back to primary with Config.TeleSwitch enabled

### DIFF
--- a/d2bs/kolbot/libs/common/Pather.js
+++ b/d2bs/kolbot/libs/common/Pather.js
@@ -323,7 +323,7 @@ const Pather = {
 			delay(5);
 		}
 
-		useTeleport && Config.TeleSwitch && me.switchWeapons(Attack.getPrimarySlot() ^ 1);
+		useTeleport && Config.TeleSwitch && me.switchWeapons(Attack.getPrimarySlot());
 		PathDebug.removeHooks();
 
 		return getDistance(me, node.x, node.y) < 5;


### PR DESCRIPTION
Resolves #390 