### PR TITLE
Gemhandling update

### DIFF
--- a/d2bs/kolbot/libs/core/Misc.js
+++ b/d2bs/kolbot/libs/core/Misc.js
@@ -644,7 +644,8 @@ const Misc = (function () {
         case sdk.shrines.Gem:
           // for now we ignore if we are gem hunting later on
           // TODO: add gem hunting logic, get gem from stash if we have one
-          return !Scripts.GemHunter;
+          console.debug("shriner: gem shrine. try my best.");
+          return Town.prepareForGemShrine();
         }
         return false;
       };
@@ -703,6 +704,7 @@ const Misc = (function () {
               }
             }
             this.getShrine(shrine);
+            Pickit.pickItems();
           }
         }
       }
@@ -794,6 +796,11 @@ const Misc = (function () {
                 shrine.objtype === Config.ScanShrines[i]
                 || (Config.ScanShrines[i] === "well" && shrine.name.toLowerCase().includes("well") && needWell())
               ) && (Pather.useTeleport() || !checkCollision(me, shrine, sdk.collision.WallOrRanged))) {
+                // Gem shrine - prepare and pick anyways
+                if (Config.ScanShrines[i] === sdk.shrines.Gem) {
+                  console.debug("scanshrines: gem shine. try my best.");
+                  Town.prepareForGemShrine();
+                }
                 this.getShrine(shrine);
 
                 // Gem shrine - pick gem

--- a/d2bs/kolbot/libs/core/Town.js
+++ b/d2bs/kolbot/libs/core/Town.js
@@ -2174,24 +2174,28 @@ const Town = {
     function pickitWantsUpgrade(unit) {
       // Stub Object to let Pickit Check
       function GemUnit(gem) {
-        this.itemType = gem["itemType"];
-        this.classid = gem["classid"];
-        this.type = gem["type"];
-        this.mode = gem["mode"];
-        this.gid = gem["gid"];
+        this.itemType = gem.itemType;
+        this.classid = gem.classid;
+        this.type = gem.type;
+        this.mode = gem.mode;
+        this.gid = gem.gid;
       }
+      // eslint-disable-next-line no-unused-vars
       GemUnit.prototype.getFlag = function (flag) {
         return true;
-      }
+      };
 
       let gem = new GemUnit(unit);
       // lets upgrade the gem
       gem.classid += 1;
-      return [Pickit.Result.WANTED, Pickit.Result.CUBING, Pickit.Result.RUNEWORD, Pickit.Result.CRAFTING].includes(Pickit.checkItem(gem).result)
+      return [
+        Pickit.Result.WANTED, Pickit.Result.CUBING,
+        Pickit.Result.RUNEWORD, Pickit.Result.CRAFTING
+      ].includes(Pickit.checkItem(gem).result);
     }
 
     // do i have any gem worth upgrading
-    const haveUpGems =  me.getItemsEx()
+    const haveUpGems = me.getItemsEx()
       .filter(function (p) {
         return isUpgradePossible(p) && pickitWantsUpgrade(p);
       })
@@ -2202,22 +2206,21 @@ const Town = {
       return false;
     }
     // we have gems that must not be upgraded in inventory
-    const isInventoryClean =  me.getItemsEx()
+    const isInventoryClean = me.getItemsEx()
       .filter(function (p) {
         return p.isInInventory && isUpgradePossible(p) && !pickitWantsUpgrade(p);
       })
       .length === 0;
 
-      // we have gems that can be upgraded in inventory
-    const isInventoryValid =  me.getItemsEx()
+    // we have gems that can be upgraded in inventory
+    const isInventoryValid = me.getItemsEx()
       .filter(function (p) {
         return p.isInInventory && isUpgradePossible(p) && pickitWantsUpgrade(p);
       })
       .length > 0;
 
-      // we already got good gems in inv and no bad games -> take shrine
-    if (isInventoryClean && isInventoryValid)
-    {
+    // we already got good gems in inv and no bad games -> take shrine
+    if (isInventoryClean && isInventoryValid) {
       console.debug("Inventory looks good. lets take the shrine.");
       return true;
     }
@@ -2225,27 +2228,27 @@ const Town = {
     const preArea = me.area;
     const preAct = me.act;
     if (!me.inTown) {
-        // not an essential function -> handle thrown errors
-        try {
-          Town.goToTown();
-        } catch (e) {
-          return false;
-        }
+      // not an essential function -> handle thrown errors
+      try {
+        Town.goToTown();
+      } catch (e) {
+        return false;
+      }
     }
 
     // stash the bad gems first
     !isInventoryClean && Town.stash();
 
     // get any good gem. flawless first (by lvlreq)
-    let goodGems =  me.getItemsEx()
+    let goodGems = me.getItemsEx()
       .filter(function (p) {
-        return  isUpgradePossible(p) && pickitWantsUpgrade(p);
+        return isUpgradePossible(p) && pickitWantsUpgrade(p);
       })
       .sort (function(a, b) {
         return b.lvlreq - a.lvlreq;
       });
     if (goodGems.length) {
-      console.debug("get Gem: "+goodGems[0].fname);
+      console.debug("get Gem: " + goodGems[0].fname);
       Town.openStash();
       Storage.Inventory.MoveTo(goodGems.first()) && Item.logger("Inventoried", goodGems[0]);
     }

--- a/d2bs/kolbot/libs/core/Town.js
+++ b/d2bs/kolbot/libs/core/Town.js
@@ -2206,7 +2206,7 @@ const Town = {
       .filter(function (p) {
         return p.isInInventory && isUpgradePossible(p) && !pickitWantsUpgrade(p);
       })
-      .length == 0;
+      .length === 0;
 
       // we have gems that can be upgraded in inventory
     const isInventoryValid =  me.getItemsEx()

--- a/d2bs/kolbot/libs/core/Town.js
+++ b/d2bs/kolbot/libs/core/Town.js
@@ -1425,76 +1425,13 @@ const Town = {
    */
   canStash: function (item) {
     if (Town.ignoreType(item.itemType)
-      || [sdk.items.quest.HoradricStaff, sdk.items.quest.KhalimsWill].includes(item.classid)
-      || !Town.canStashGem(item)) {
+      || [sdk.items.quest.HoradricStaff, sdk.items.quest.KhalimsWill].includes(item.classid)) {
       return false;
     }
     /**
      * @todo add sorting here first if we can't fit the item
      */
     return Storage.Stash.CanFit(item);
-  },
-
-  /**
-   * get ordered list of gems in inventory to use with Gem Hunter Script
-   * @returns {ItemUnit[]} ordered list of relevant gems
-   */
-  getGemsInInv: function () {
-    let GemList = Config.GemHunter.GemList;
-    return me.getItemsEx()
-      .filter((p) => p.isInInventory && GemList.includes(p.classid))
-      .sort((a, b) => GemList.indexOf(a.classid) - GemList.indexOf(b.classid));
-  },
-
-  /**
-   * get ordered list of gems in stash to use with Gem Hunter Script
-   * @returns {ItemUnit[]} ordered list of relevant gems
-   */
-  getGemsInStash: function () {
-    let GemList = Config.GemHunter.GemList;
-    return me.getItemsEx()
-      .filter((p) => p.isInStash && GemList.includes(p.classid))
-      .sort((a, b) => GemList.indexOf(a.classid) - GemList.indexOf(b.classid));
-  },
-
-  /**
-   * gem check for use with Gem Hunter Script
-   * @param {ItemUnit} item 
-   * @returns {boolean} if we should stash this gem
-   */
-  canStashGem: function (item) {
-    // we aren't using the gem hunter script or we aren't scanning for the gem shrines while moving
-    // for now we are only going to keep a gem in our invo while the script is active
-    if (Loader.scriptName() !== "GemHunter") return true;
-    // not in our list
-    if (Config.GemHunter.GemList.indexOf(item.classid) === -1) return true;
-
-    let GemList = Config.GemHunter.GemList;
-    let gemsInStash = Town.getGemsInStash();
-    let bestGeminStash = gemsInStash.length > 0 ? gemsInStash.first().classid : -1;
-    let gemsInInvo = Town.getGemsInInv();
-    let bestGeminInv = gemsInInvo.length > 0 ? gemsInInvo.first().classid : -1;
-
-    return (
-      (GemList.indexOf(bestGeminStash) < GemList.indexOf(bestGeminInv)) // better one in stash
-      || (GemList.indexOf(bestGeminInv) < GemList.indexOf(item.classid)) // better one in inv
-      || (gemsInInvo.filter((p) => p.classid === item.classid).length > 1));  // another one in inv
-  },
-
-  /**
-   * move best gem from stash to inventory, if none in inventrory
-   * to use with Gem Hunter Script
-   * @returns {boolean} if any gem has been moved
-   */
-  getGem: function () {
-    if (Loader.scriptName() === "GemHunter") {
-      if (Town.getGemsInInv().length === 0 && Town.getGemsInStash().length > 0) {
-        let gem = Town.getGemsInStash().first();
-        Storage.Inventory.MoveTo(gem) && Item.logger("Inventoried", gem);
-        return true;
-      }
-    }
-    return false;
   },
 
   /**
@@ -2218,5 +2155,114 @@ const Town = {
     console.info(false, "CurrentArea: " + getAreaName(me.area));
 
     return true;
+  },
+
+  /**
+   * @description get a gem worthy upgrading to inventory. go town if needed
+   * @returns {boolean} If a gem to upgrade is in inventory
+   */
+  prepareForGemShrine: function () {
+
+    function isUpgradePossible(unit) {
+      return (
+        unit.itemType >= sdk.items.type.Amethyst
+        && unit.itemType <= sdk.items.type.Skull
+        && !Object.values(sdk.items.gems.Perfect).includes(unit.classid)
+      );
+    }
+
+    function pickitWantsUpgrade(unit) {
+      // Stub Object to let Pickit Check
+      function GemUnit(gem) {
+        this.itemType = gem["itemType"];
+        this.classid = gem["classid"];
+        this.type = gem["type"];
+        this.mode = gem["mode"];
+        this.gid = gem["gid"];
+      }
+      GemUnit.prototype.getFlag = function (flag) {
+        return true;
+      }
+
+      let gem = new GemUnit(unit);
+      // lets upgrade the gem
+      gem.classid += 1;
+      return [Pickit.Result.WANTED, Pickit.Result.CUBING, Pickit.Result.RUNEWORD, Pickit.Result.CRAFTING].includes(Pickit.checkItem(gem).result)
+    }
+
+    // do i have any gem worth upgrading
+    const haveUpGems =  me.getItemsEx()
+      .filter(function (p) {
+        return isUpgradePossible(p) && pickitWantsUpgrade(p);
+      })
+      .length > 0;
+
+    if (!haveUpGems) {
+      console.debug("I dont have any gems worth upgrading");
+      return false;
+    }
+    // we have gems that must not be upgraded in inventory
+    const isInventoryClean =  me.getItemsEx()
+      .filter(function (p) {
+        return p.isInInventory && isUpgradePossible(p) && !pickitWantsUpgrade(p);
+      })
+      .length == 0;
+
+      // we have gems that can be upgraded in inventory
+    const isInventoryValid =  me.getItemsEx()
+      .filter(function (p) {
+        return p.isInInventory && isUpgradePossible(p) && pickitWantsUpgrade(p);
+      })
+      .length > 0;
+
+      // we already got good gems in inv and no bad games -> take shrine
+    if (isInventoryClean && isInventoryValid)
+    {
+      console.debug("Inventory looks good. lets take the shrine.");
+      return true;
+    }
+    // go to town
+    const preArea = me.area;
+    const preAct = me.act;
+    if (!me.inTown) {
+        // not an essential function -> handle thrown errors
+        try {
+          Town.goToTown();
+        } catch (e) {
+          return false;
+        }
+    }
+
+    // stash the bad gems first
+    !isInventoryClean && Town.stash();
+
+    // get any good gem. flawless first (by lvlreq)
+    let goodGems =  me.getItemsEx()
+      .filter(function (p) {
+        return  isUpgradePossible(p) && pickitWantsUpgrade(p);
+      })
+      .sort (function(a, b) {
+        return b.lvlreq - a.lvlreq;
+      });
+    if (goodGems.length) {
+      console.debug("get Gem: "+goodGems[0].fname);
+      Town.openStash();
+      Storage.Inventory.MoveTo(goodGems.first()) && Item.logger("Inventoried", goodGems[0]);
+    }
+
+    // leave town
+    me.act !== preAct && Town.goToTown(preAct);
+    Town.move("portalspot");
+
+    if (!Pather.usePortal(null, me.name)) {
+      try {
+        Pather.usePortal(preArea, me.name);
+      } catch (e) {
+        throw new Error("Town.visitTown: Failed to go back from town");
+      }
+    }
+
+    Config.PublicMode && Pather.makePortal();
+    return (goodGems.length);
   }
 };

--- a/d2bs/kolbot/libs/scripts/GemHunter.js
+++ b/d2bs/kolbot/libs/scripts/GemHunter.js
@@ -15,25 +15,21 @@
 const GemHunter = new Runnable(
   function GemHunter () {
     Town.doChores();
-    Town.getGem();
-    if (Town.getGemsInInv().length === 0) {
+    if (!Town.prepareForGemShrine()) {
       console.log("ÿc4GemHunterÿc0: no gems in inventory - aborting.");
       return false;
     }
 
     for (let area of Config.GemHunter.AreaList) {
-      if (Town.getGemsInInv().length > 0) {
-        console.log("ÿc4GemHunterÿc0: Moving to " + getAreaName(area));
-        Pather.journeyTo(area);
-        if (i % 2 === 0) Precast.doPrecast(true);
-        if (Misc.getShrinesInArea(area, sdk.shrines.Gem, true)) {
-          Pickit.pickItems();
-          console.log("ÿc4GemHunterÿc0: found a gem Shrine");
-          if ((Town.getGemsInInv().length === 0) && (Town.getGemsInStash().length > 0)) {
-            console.log("ÿc4GemHunterÿc0: Getting a new Gem in Town.");
-            Town.visitTown(); // Go to Town and do chores. Will throw an error if it fails to return from Town.
-            Town.getGem();
-          }
+      console.log("ÿc4GemHunterÿc0: Moving to " + getAreaName(area));
+      Pather.journeyTo(area);
+      Precast.doPrecast(false);
+      if (Misc.getShrinesInArea(area, sdk.shrines.Gem, true)) {
+        Pickit.pickItems();
+        console.log("ÿc4GemHunterÿc0: found a gem Shrine");
+        if (!Town.prepareForGemShrine()) {
+          console.log("ÿc4GemHunterÿc0: more gems in inventory - aborting.");
+          return false;
         }
       }
     }

--- a/d2bs/kolbot/libs/scripts/GemHunter.js
+++ b/d2bs/kolbot/libs/scripts/GemHunter.js
@@ -1,6 +1,6 @@
 /**
 *  @filename    GemHunter.js
-*  @author      icommitdesnet
+*  @author      icommitdesnet, theBGuy
 *  @desc        hunt gem shrines
 *
 */
@@ -14,28 +14,86 @@
  */
 const GemHunter = new Runnable(
   function GemHunter () {
-    Town.doChores();
     if (!Town.prepareForGemShrine()) {
       console.log("ÿc4GemHunterÿc0: no gems in inventory - aborting.");
       return false;
     }
 
+    /** @param {number} area */
+    const findGemShrines = function (area) {
+      const shrineLocs = [];
+      const units = Game.getPresetObjects(area)
+        .filter(function (preset) {
+          return sdk.shrines.Presets.includes(preset.id);
+        });
+
+      if (units.length) {
+        for (let shrine of units) {
+          shrineLocs.push(shrine.realCoords());
+        }
+      }
+
+      try {
+        NodeAction.shrinesToIgnore.push(sdk.shrines.Gem);
+
+        while (shrineLocs.length > 0) {
+          shrineLocs.sort(Sort.units);
+          let coords = shrineLocs.shift();
+
+          Pather.move(coords, { minDist: Skill.haveTK ? 20 : 5, callback: () => {
+            let shrine = Game.getObject("shrine");
+            return !!shrine && shrine.x === coords.x && shrine.y === coords.y;
+          } });
+
+          let shrine = Game.getObject("shrine");
+
+          if (shrine) {
+            do {
+              if (shrine.objtype === sdk.shrines.Gem && shrine.mode === sdk.objects.mode.Inactive) {
+                (!Skill.haveTK || !use) && Pather.moveTo(shrine.x - 2, shrine.y - 2);
+
+                console.log("ÿc4GemHunterÿc0: found a gem Shrine");
+                if (Misc.getShrine(shrine)) {
+                  Pickit.pickItems();
+
+                  if (!Town.prepareForGemShrine()) {
+                    console.error("ÿc4GemHunterÿc0: failed to prepare for next shrine - aborting.");
+                    return false;
+                  }
+                }
+              }
+            } while (shrine.getNext());
+          }
+        }
+
+        return true;
+      } finally {
+        NodeAction.shrinesToIgnore.remove(sdk.shrines.Gem);
+      }
+    };
+
     for (let area of Config.GemHunter.AreaList) {
       console.log("ÿc4GemHunterÿc0: Moving to " + getAreaName(area));
       Pather.journeyTo(area);
       Precast.doPrecast(false);
-      if (Misc.getShrinesInArea(area, sdk.shrines.Gem, true)) {
-        Pickit.pickItems();
-        console.log("ÿc4GemHunterÿc0: found a gem Shrine");
-        if (!Town.prepareForGemShrine()) {
-          console.log("ÿc4GemHunterÿc0: more gems in inventory - aborting.");
-          return false;
-        }
+      
+      if (!findGemShrines(area)) {
+        console.debug("ending early");
+        break;
       }
     }
     return true;
   },
   {
-    preAction: null
+    preAction: function (ctx) {
+      ctx.preGidList = new Set(Town.dontStashGids);
+    },
+    cleanup: function (ctx) {
+      for (let gid of Town.dontStashGids) {
+        if (!ctx.preGidList.has(gid)) {
+          Town.dontStashGids.delete(gid);
+        }
+      }
+    }
   }
 );

--- a/d2bs/kolbot/sdk/types/Pickit.d.ts
+++ b/d2bs/kolbot/sdk/types/Pickit.d.ts
@@ -18,6 +18,7 @@ declare global {
     const Result: PickitResult;
     const tkable: number[];
     const essentials: number[];
+    const systemKeep: { reason: string, gid: number }[];
 
     function init(notify: any): void;
     function itemEvent(gid?: number, mode?: number, code?: number, global?: number): void;

--- a/d2bs/kolbot/sdk/types/Town.d.ts
+++ b/d2bs/kolbot/sdk/types/Town.d.ts
@@ -4,6 +4,7 @@ declare global {
     let telekinesis: boolean;
     let sellTimer: number;
     let lastChores: number;
+    const dontStashGids: Set<number>;
 
     const tasks: Map<Act, {
       Heal: NPC;

--- a/d2bs/kolbot/sdk/types/Town.d.ts
+++ b/d2bs/kolbot/sdk/types/Town.d.ts
@@ -74,6 +74,7 @@ declare global {
     function moveToSpot(spot?: string, allowTK?: boolean): boolean;
     function goToTown(act?: 2 | 1 | 4 | 3 | 5, wpmenu?: boolean): boolean;
     function visitTown(repair?: boolean): boolean;
+    function prepareForGemShrine(): boolean;
   }
 }
 export {};


### PR DESCRIPTION
let pickit decide, if we want an  upgrade. not sure if solution is acceptable: see `function GemUnit(gem)` (Town.js 2176)
check for gem upgrade before picking a gemshrine (autoshriner and scanshrine). if there is, even go to town before picking.
removed old code from town.js
no collecting of chipped gems with gem shrines. leave them for others or 1.09