### PR TITLE
fix: Comply with what is being asked when using Proxy

### DIFF
--- a/d2bs/kolbot/libs/modules/Worker.js
+++ b/d2bs/kolbot/libs/modules/Worker.js
@@ -82,6 +82,7 @@
           }
         };
         self.pushLowPrio(proxyCallback);
+        return true;
       },
       deleteProperty: function (target, name) {
         if (!target.processes.hasOwnProperty(name)) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set#return_value

Can throw a type error when used in strict mode otherwise