### PR TITLE
fix: Fix missing variable declaration

### DIFF
--- a/d2bs/kolbot/libs/core/Common/Cows.js
+++ b/d2bs/kolbot/libs/core/Common/Cows.js
@@ -101,8 +101,8 @@
         }
       }
 
+      let room;
       RoomLoop:
-      let room;      
       while (rooms.length > 0) {
         // get the first room + initialize myRoom var
         !myRoom && (room = getRoom(me.x, me.y));

--- a/d2bs/kolbot/libs/core/Common/Cows.js
+++ b/d2bs/kolbot/libs/core/Common/Cows.js
@@ -102,6 +102,7 @@
       }
 
       RoomLoop:
+      let room;      
       while (rooms.length > 0) {
         // get the first room + initialize myRoom var
         !myRoom && (room = getRoom(me.x, me.y));


### PR DESCRIPTION
`Cannot access 'room' before initialization`