### PR TITLE
mulelogger: Add Header for Merc Items

### DIFF
--- a/d2bs/kolbot/libs/systems/mulelogger/MuleLogger.js
+++ b/d2bs/kolbot/libs/systems/mulelogger/MuleLogger.js
@@ -344,6 +344,7 @@ const MuleLogger = {
 
         for (let item of mercItems) {
           let parsedItem = this.logItem(item);
+          !parsedItem.header && (parsedItem.header = (me.account || "Single Player") + " / " + me.name);
           parsedItem.title += " (merc)";
           let string = JSON.stringify(parsedItem);
           finalString += (string + "\n");


### PR DESCRIPTION
merc items header is blank
(blank/blank/SEN) 
this will change to (acc / char / SEN)
to make finding merc items easier in Char Viewer