### PR TITLE
Add ItemiLevel to itemString in ToolsThread.js

### DIFF
--- a/d2bs/kolbot/threads/ToolsThread.js
+++ b/d2bs/kolbot/threads/ToolsThread.js
@@ -153,12 +153,13 @@ function main () {
           itemString = (
             "ÿc4ItemName: ÿc0" + itemToCheck.prettyPrint
             + "\nÿc4ItemType: ÿc0" + itemToCheck.itemType
-            + "| ÿc4Classid: ÿc0" + itemToCheck.classid
-            + "| ÿc4Quality: ÿc0" + itemToCheck.quality
-            + "| ÿc4Gid: ÿc0" + itemToCheck.gid
+            + " | ÿc4Classid: ÿc0" + itemToCheck.classid
+            + " | ÿc4Quality: ÿc0" + itemToCheck.quality
+            + " | ÿc4Gid: ÿc0" + itemToCheck.gid
             + "\nÿc4ItemMode: ÿc0" + itemToCheck.mode
-            + "| ÿc4Location: ÿc0" + itemToCheck.location
-            + "| ÿc4Bodylocation: ÿc0" + itemToCheck.bodylocation
+            + " | ÿc4Location: ÿc0" + itemToCheck.location
+            + " | ÿc4Bodylocation: ÿc0" + itemToCheck.bodylocation
+            + " | ÿc4Item Level: ÿc0" + itemToCheck.ilvl
           );
           generalString = pString + nString
             + "\nÿc4Cubing Item: ÿc0" + Cubing.keepItem(itemToCheck)


### PR DESCRIPTION
added ilvl to "numpad ." for easy way to check or verify iLvl of items within regular bot play
added spaces to existing formatting for easier reading so it matches the other existing format