### PR TITLE
Implement shrine check for XP shrine status

### DIFF
--- a/d2bs/kolbot/libs/scripts/BaalAssistant.js
+++ b/d2bs/kolbot/libs/scripts/BaalAssistant.js
@@ -40,25 +40,25 @@ const BaalAssistant = new Runnable(
       Config.BaalAssistant.NextGameMessage[i] = msg.toLowerCase();
     });
 
- function CheckShrine() {  // Check if XP shrine is still active, restore Helper to original config setting.
-    // If we never had a shrine, do nothing
-    if (!shrineActive)
+	function CheckShrine() {  // Check if XP shrine is still active, restore Helper to original config setting.
+      // If we never had a shrine, do nothing
+      if (!shrineActive)
         return;
 
-    const now = getTickCount(); 
-    // throttle: only allow once per 1000 ms
-    if (now - lastShrineCheck < 1000) {
+      const now = getTickCount(); 
+      // throttle: only allow once per 1000 ms
+      if (now - lastShrineCheck < 1000) {
         return; // skip
-    }
-    lastShrineCheck = now;
+      }
+      lastShrineCheck = now;
 
-    // If shrine buff is gone, shrine expired
-    if (!me.getState(sdk.states.ShrineExperience)) {
+      // If shrine buff is gone, shrine expired
+      if (!me.getState(sdk.states.ShrineExperience)) {
         Helper = Config.BaalAssistant.Helper;
         shrineActive = false;
         console.debug("XP shrine expired or removed, Helper restored to original config setting.");
-    }
-}
+      }
+	}
     
     const chatEvent = function (nick, msg) {
       if (nick === Leader) {
@@ -265,7 +265,7 @@ const BaalAssistant = new Runnable(
                   }
                   if (Misc.getShrinesInArea(i, sdk.shrines.Experience, true)) {
                     shrineActive = true;
-					          Helper = false;
+					Helper = false;
                     break;
                   }
                 }
@@ -282,7 +282,7 @@ const BaalAssistant = new Runnable(
                       }
                       if (Misc.getShrinesInArea(i, sdk.shrines.Experience, true)) {
                         shrineActive = true;
-					              Helper = false;
+					    Helper = false;
                         break;
                       }
                     }
@@ -512,13 +512,13 @@ const BaalAssistant = new Runnable(
 
                 }
                 if (Helper || Config.BaalAssistant.HurtBaal > 0) { // shrine was removed and Helper enabled
-                Pather.moveTo(15134, 5923);
-                Config.BaalAssistant.HurtBaal > 0
-                  ? Attack.hurt(sdk.monsters.Baal, Config.BaalAssistant.HurtBaal)
-                  : Attack.kill(sdk.monsters.Baal);
-                Pickit.pickItems();
-              }
-
+				  Pather.moveTo(15134, 5923);
+				  Config.BaalAssistant.HurtBaal > 0
+				  ? Attack.hurt(sdk.monsters.Baal, Config.BaalAssistant.HurtBaal)
+				  : Attack.kill(sdk.monsters.Baal);
+				  Pickit.pickItems();
+				}
+			  }
             } else {
               // how to accurately know when to end script in the instance of no ngCheck
               // listen for baal death packet maybe?

--- a/d2bs/kolbot/libs/scripts/BaalAssistant.js
+++ b/d2bs/kolbot/libs/scripts/BaalAssistant.js
@@ -265,7 +265,7 @@ const BaalAssistant = new Runnable(
                   }
                   if (Misc.getShrinesInArea(i, sdk.shrines.Experience, true)) {
                     shrineActive = true;
-					Helper = false;
+					          Helper = false;
                     break;
                   }
                 }
@@ -282,7 +282,7 @@ const BaalAssistant = new Runnable(
                       }
                       if (Misc.getShrinesInArea(i, sdk.shrines.Experience, true)) {
                         shrineActive = true;
-					    Helper = false;
+					              Helper = false;
                         break;
                       }
                     }
@@ -511,14 +511,14 @@ const BaalAssistant = new Runnable(
                   CheckShrine();
 
                 }
-                if (Helper || Config.BaalAssistant.HurtBaal > 0) { // shrine was removed and Helper enabled
-				  Pather.moveTo(15134, 5923);
-				  Config.BaalAssistant.HurtBaal > 0
-				  ? Attack.hurt(sdk.monsters.Baal, Config.BaalAssistant.HurtBaal)
-				  : Attack.kill(sdk.monsters.Baal);
-				  Pickit.pickItems();
-				}
-			  }
+                if (Helper || Config.BaalAssistant.HurtBaal > 0) {    // shrine was removed and Helper enabled
+                  Pather.moveTo(15134, 5923);
+                  Config.BaalAssistant.HurtBaal > 0
+                    ? Attack.hurt(sdk.monsters.Baal, Config.BaalAssistant.HurtBaal)
+                    : Attack.kill(sdk.monsters.Baal);
+				          Pickit.pickItems();
+                }
+              }
             } else {
               // how to accurately know when to end script in the instance of no ngCheck
               // listen for baal death packet maybe?

--- a/d2bs/kolbot/libs/scripts/BaalAssistant.js
+++ b/d2bs/kolbot/libs/scripts/BaalAssistant.js
@@ -20,7 +20,9 @@ const BaalAssistant = new Runnable(
     let quitFlag = false;
     let [hotCheck, safeCheck, baalCheck, ngCheck, baalIsDead] = [false, false, false, false, false];
     let [ShrineStatus, secondAttempt, throneStatus, killTracker] = [false, false, false, false];
-
+    let shrineActive = false; // if we have a xp shrine
+    let lastShrineCheck = 0; // for check throttle
+    
     // convert all messages to lowercase
     Config.BaalAssistant.HotTPMessage.forEach((msg, i) => {
       Config.BaalAssistant.HotTPMessage[i] = msg.toLowerCase();
@@ -38,6 +40,26 @@ const BaalAssistant = new Runnable(
       Config.BaalAssistant.NextGameMessage[i] = msg.toLowerCase();
     });
 
+ function CheckShrine() {  // Check if XP shrine is still active, restore Helper to original config setting.
+    // If we never had a shrine, do nothing
+    if (!shrineActive)
+        return;
+
+    const now = getTickCount(); 
+    // throttle: only allow once per 1000 ms
+    if (now - lastShrineCheck < 1000) {
+        return; // skip
+    }
+    lastShrineCheck = now;
+
+    // If shrine buff is gone, shrine expired
+    if (!me.getState(sdk.states.ShrineExperience)) {
+        Helper = Config.BaalAssistant.Helper;
+        shrineActive = false;
+        console.debug("XP shrine expired or removed, Helper restored to original config setting.");
+    }
+}
+    
     const chatEvent = function (nick, msg) {
       if (nick === Leader) {
         if ((Config.BaalAssistant.DollQuit && msg === "Dolls found! NG.")
@@ -242,6 +264,8 @@ const BaalAssistant = new Runnable(
                     break;
                   }
                   if (Misc.getShrinesInArea(i, sdk.shrines.Experience, true)) {
+                    shrineActive = true;
+					          Helper = false;
                     break;
                   }
                 }
@@ -257,6 +281,8 @@ const BaalAssistant = new Runnable(
                         break;
                       }
                       if (Misc.getShrinesInArea(i, sdk.shrines.Experience, true)) {
+                        shrineActive = true;
+					              Helper = false;
                         break;
                       }
                     }
@@ -382,6 +408,7 @@ const BaalAssistant = new Runnable(
                   }
 
                   if (!Game.getMonster(sdk.monsters.ThroneBaal)) {
+                    CheckShrine();
                     break;
                   }
 
@@ -389,21 +416,25 @@ const BaalAssistant = new Runnable(
                   case 1:
                     Helper && Attack.clear(40);
                     tick = getTickCount();
+                    CheckShrine();
 
                     break;
                   case 2:
                     Helper && Attack.clear(40);
                     tick = getTickCount();
+                    CheckShrine();
 
                     break;
                   case 4:
                     Helper && Attack.clear(40);
                     tick = getTickCount();
+                    CheckShrine();
 
                     break;
                   case 3:
                     Helper && Attack.clear(40) && Common.Baal.checkHydra();
                     tick = getTickCount();
+                    CheckShrine();
 
                     break;
                   case 5:
@@ -414,9 +445,11 @@ const BaalAssistant = new Runnable(
                         .map((unitId) => Game.getMonster(unitId))
                         .filter(Boolean).some((unit) => unit.attackable)) {
                         delay(1000);
+                        CheckShrine();
                       }
 
                       delay(1000);
+                      CheckShrine();
                     }
 
                     break MainLoop;
@@ -455,6 +488,7 @@ const BaalAssistant = new Runnable(
               let portal = Game.getObject(sdk.objects.WorldstonePortal);
 
               if (portal) {
+                CheckShrine();
                 delay((Helper ? 1000 : 4000));
                 Pather.usePortal(null, null, portal);
               } else {
@@ -472,9 +506,17 @@ const BaalAssistant = new Runnable(
                 Pather.moveTo(15177, 5952);
                 let baal = Game.getMonster(sdk.monsters.Baal);
                 
-                while (!!baal && baal.attackable && !baalIsDead) {
+                while (!!baal && baal.attackable && !baalIsDead && !Helper) {
                   delay(1000);
+                  CheckShrine();
+
                 }
+                if (Helper || Config.BaalAssistant.HurtBaal > 0) { // shrine was removed and Helper enabled
+                Pather.moveTo(15134, 5923);
+                Config.BaalAssistant.HurtBaal > 0
+                  ? Attack.hurt(sdk.monsters.Baal, Config.BaalAssistant.HurtBaal)
+                  : Attack.kill(sdk.monsters.Baal);
+                Pickit.pickItems();
               }
 
             } else {


### PR DESCRIPTION
Added shrine check functionality to monitor XP shrine status and restore Helper settings when the shrine expires.

Tired of deciding between getting XP shrine or Killing waves and Baal ?  Now you dont have to.  This code will get shrines if enabled in charconfig,  it will also fight if you failed to find a shrine or if the shrine expires or gets cursed off, if you have Helper enabled.  No extra settings. Get back in the fight !


please review and make any changes as needed. 
when a shrine is picked up it disables Helper.
i added the CheckShrine after each wave, at red portal, and then in the leech spot loop.(and some extra places, maybe it doesnt need them all?) if shrine status is removed it will restore Helper and pick up the fight. tested 500 runs with Helper and Shrine. (but before the Hurt addition so i just guessed at that part)