### PR TITLE
Implement handle updates in D2Bot initialization

### DIFF
--- a/d2bs/kolbot/libs/oog/D2Bot.js
+++ b/d2bs/kolbot/libs/oog/D2Bot.js
@@ -25,6 +25,13 @@ includeIfNotIncluded("oog/DataFile.js");
     _entry: "",
 
     init: function () {
+      // Pick up handle updates, in case the instance is taken over by a new manager.
+      addEventListener("copydata", function (mode, msg) {
+        if (msg === "Handle" && typeof mode === "number") {
+          D2Bot.handle = mode;
+        }
+      });
+
       let handle = DataFile.getStats().handle;
 
       if (handle) {


### PR DESCRIPTION
Added event listener to handle updates for D2Bot.
This allows the manager to restart post update, without losing track of the games, by send a new message with the new handle.