### PR TITLE
Add InvTrans property to logged items

### DIFF
--- a/d2bs/kolbot/libs/core/Item.js
+++ b/d2bs/kolbot/libs/core/Item.js
@@ -533,6 +533,7 @@ const Item = {
       let lastArea;
       const name = unit.fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<:;.*]|\/|\\/g, "").trim();
       const color = (unit.getColor() || -1);
+      const invTrans = (getBaseStat("items", unit.classid, "InvTrans") || 0);
       const code = this.getItemCode(unit);
       const sock = unit.getItem();
       let desc = this.getItemDesc(unit);
@@ -561,6 +562,7 @@ const Item = {
         image: code,
         textColor: unit.quality,
         itemColor: color,
+        invTrans: invTrans,
         header: "",
         sockets: this.getItemSockets(unit)
       };

--- a/d2bs/kolbot/libs/systems/mulelogger/MuleLogger.js
+++ b/d2bs/kolbot/libs/systems/mulelogger/MuleLogger.js
@@ -256,6 +256,7 @@ const MuleLogger = {
 
     return {
       itemColor: color,
+      invTrans: (getBaseStat("items", unit.classid, "InvTrans") || 0),
       image: code,
       title: name,
       description: desc,


### PR DESCRIPTION
This is one of the reasons why items such as Tal Mask logged to D2Bot have a weird tint.
D2Bot manager only ships a single palette file (yet there are 6 or so), and ends up rendering it wrong.
This adds the required info so that some undescribed, other manager, could render it correctly.